### PR TITLE
Add policy creation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,8 @@ gem 'gds-sso', '10.0.0'
 gem 'plek', '1.10.0'
 gem 'airbrake', '4.1.0'
 gem 'govuk_admin_template', '1.5.1'
+gem 'generic_form_builder', '0.11.0'
+gem 'decent_exposure', '2.3.2'
 
 group :development, :test do
   gem 'byebug'

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'quiet_assets', '1.1.0'
 gem 'gds-sso', '10.0.0'
 gem 'plek', '1.10.0'
 gem 'airbrake', '4.1.0'
-gem 'govuk_admin_template', '1.5.0'
+gem 'govuk_admin_template', '1.5.1'
 
 group :development, :test do
   gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,7 @@ GEM
     database_cleaner (1.4.0)
     debug_inspector (0.0.2)
     debugger-linecache (1.2.0)
+    decent_exposure (2.3.2)
     diff-lcs (1.2.5)
     erubis (2.7.0)
     execjs (2.3.0)
@@ -97,6 +98,7 @@ GEM
       rails (>= 3.0.0)
       warden (~> 1.2)
       warden-oauth2 (~> 0.0.1)
+    generic_form_builder (0.11.0)
     gherkin (2.12.2)
       multi_json (~> 1.3)
     globalid (0.3.0)
@@ -252,8 +254,10 @@ DEPENDENCIES
   byebug
   cucumber-rails
   database_cleaner
+  decent_exposure (= 2.3.2)
   factory_girl_rails
   gds-sso (= 10.0.0)
+  generic_form_builder (= 0.11.0)
   govuk_admin_template (= 1.5.1)
   launchy
   pg

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,7 +41,7 @@ GEM
       builder
       multi_json
     arel (6.0.0)
-    autoprefixer-rails (5.1.3)
+    autoprefixer-rails (5.1.5)
       execjs
       json
     binding_of_caller (0.7.2)
@@ -101,7 +101,7 @@ GEM
       multi_json (~> 1.3)
     globalid (0.3.0)
       activesupport (>= 4.1.0)
-    govuk_admin_template (1.5.0)
+    govuk_admin_template (1.5.1)
       bootstrap-sass (~> 3.3.3)
       jquery-rails (~> 3.1.1)
       rails (>= 3.2.0)
@@ -254,7 +254,7 @@ DEPENDENCIES
   database_cleaner
   factory_girl_rails
   gds-sso (= 10.0.0)
-  govuk_admin_template (= 1.5.0)
+  govuk_admin_template (= 1.5.1)
   launchy
   pg
   plek (= 1.10.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,4 +5,8 @@ class ApplicationController < ActionController::Base
 
   include GDS::SSO::ControllerMethods
   before_filter :require_signin_permission!
+
+  decent_configuration do
+    strategy DecentExposure::StrongParametersStrategy
+  end
 end

--- a/app/controllers/policies_controller.rb
+++ b/app/controllers/policies_controller.rb
@@ -1,3 +1,25 @@
 class PoliciesController < ApplicationController
+  expose(:policy, attributes: :policy_params)
+  expose(:policies)
+
   def index; end
+
+  def new; end
+
+  def create
+    if policy.save
+      redirect_to policies_path
+    else
+      render :new
+    end
+  end
+
+private
+
+  def policy_params
+    params.require(:policy).permit(
+      :name,
+      :description
+    )
+  end
 end

--- a/app/models/policy.rb
+++ b/app/models/policy.rb
@@ -1,0 +1,5 @@
+class Policy < ActiveRecord::Base
+  before_create do |policy|
+    policy.slug = policy.name.parameterize
+  end
+end

--- a/app/views/policies/index.html.erb
+++ b/app/views/policies/index.html.erb
@@ -1,3 +1,13 @@
 <%= content_for :page_title, "Policies" %>
 
 <h1>Policies</h1>
+
+<p>
+  <%= link_to "Create a policy", new_policy_path %>
+</p>
+
+<ul>
+  <% policies.each do |policy| %>
+    <li><%= policy.name %></li>
+  <% end %>
+</ul>

--- a/app/views/policies/new.html.erb
+++ b/app/views/policies/new.html.erb
@@ -1,0 +1,8 @@
+<h1>Create a policy</h1>
+
+<%= form_for policy do |f| %>
+  <%= f.text_field :name %>
+  <%= f.text_area :description %>
+
+  <button>Save this policy</button>
+<% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -30,5 +30,9 @@ module PolicyPublisher
 
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true
+
+    # Better forms
+    config.action_view.default_form_builder = GenericFormBuilder
+    config.action_view.field_error_proc = proc {|html_tag, _| html_tag }
   end
 end

--- a/db/migrate/20150209135410_create_policy.rb
+++ b/db/migrate/20150209135410_create_policy.rb
@@ -1,0 +1,10 @@
+class CreatePolicy < ActiveRecord::Migration
+  def change
+    create_table :policies do |t|
+      t.string :slug
+      t.string :name
+      t.text :description
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150209100815) do
+ActiveRecord::Schema.define(version: 20150209135410) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "policies", force: :cascade do |t|
+    t.string   "slug"
+    t.string   "name"
+    t.text     "description"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string  "name"

--- a/features/policy_creation.feature
+++ b/features/policy_creation.feature
@@ -1,0 +1,9 @@
+Feature: Policy creation
+
+As a content editor
+I need to be able to create and edit policies
+In order to inform the nation about our government's intentions for a topic.
+
+Scenario: Creating a policy
+  When I create a policy called "Climate change"
+  Then there should be a policy called "Climate change"

--- a/features/step_definitions/policy_creation_steps.rb
+++ b/features/step_definitions/policy_creation_steps.rb
@@ -1,0 +1,7 @@
+When(/^I create a policy called "(.*?)"$/) do |policy_name|
+  create_policy(name: policy_name)
+end
+
+Then(/^there should be a policy called "(.*?)"$/) do |policy_name|
+  check_for_policy(name: policy_name)
+end

--- a/features/support/authentication.rb
+++ b/features/support/authentication.rb
@@ -1,0 +1,3 @@
+Before do
+  FactoryGirl.create(:user)
+end

--- a/features/support/policy_helpers.rb
+++ b/features/support/policy_helpers.rb
@@ -1,0 +1,18 @@
+module PolicyHelpers
+  def create_policy(name:, description: "A policy description")
+    visit policies_path
+    click_on "Create a policy"
+
+    fill_in "Name", with: name
+    fill_in "Description", with: description
+
+    click_on "Save this policy"
+  end
+
+  def check_for_policy(name:)
+    visit policies_path
+    expect(page).to have_content(name)
+  end
+end
+
+World(PolicyHelpers)

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,0 +1,9 @@
+FactoryGirl.define do
+  factory :user do
+    permissions { ["signin"] }
+  end
+
+  factory :policy do
+    sequence(:name) {|n| "Policy #{n}" }
+  end
+end

--- a/spec/models/policy_spec.rb
+++ b/spec/models/policy_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe Policy do
+  it "automatically adds a slug on creation" do
+    policy = Policy.create!(name: "Climate change")
+
+    expect(policy.slug).to eq("climate-change")
+  end
+
+  it "doesn't change the slug when the name changes" do
+    policy = FactoryGirl.create(:policy, name: "Climate change")
+
+    policy.name = "Immigration"
+    policy.save!
+
+    expect(policy.slug).to eq("climate-change")
+  end
+end


### PR DESCRIPTION
Allows the creation and listing of policies.

Policies automatically set a slug based on the name at creation, but not when saved.

https://trello.com/c/44banZNs/1-allow-policies-to-be-created-in-the-policy-publisher