### PR TITLE
Form styling

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'gds-sso', '10.0.0'
 gem 'plek', '1.10.0'
 gem 'airbrake', '4.1.0'
 gem 'govuk_admin_template', '1.5.1'
-gem 'generic_form_builder', '0.11.0'
+gem 'generic_form_builder', '0.12.0'
 gem 'decent_exposure', '2.3.2'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,7 +98,7 @@ GEM
       rails (>= 3.0.0)
       warden (~> 1.2)
       warden-oauth2 (~> 0.0.1)
-    generic_form_builder (0.11.0)
+    generic_form_builder (0.12.0)
     gherkin (2.12.2)
       multi_json (~> 1.3)
     globalid (0.3.0)
@@ -257,7 +257,7 @@ DEPENDENCIES
   decent_exposure (= 2.3.2)
   factory_girl_rails
   gds-sso (= 10.0.0)
-  generic_form_builder (= 0.11.0)
+  generic_form_builder (= 0.12.0)
   govuk_admin_template (= 1.5.1)
   launchy
   pg

--- a/app/views/policies/index.html.erb
+++ b/app/views/policies/index.html.erb
@@ -6,8 +6,28 @@
   <%= link_to "Create a policy", new_policy_path %>
 </p>
 
-<ul>
-  <% policies.each do |policy| %>
-    <li><%= policy.name %></li>
-  <% end %>
-</ul>
+<table class="table table-striped table-bordered" data-module="filterable-table">
+  <thead>
+    <tr class="table-header">
+      <th>Name</th>
+      <th>Last updated</th>
+    </tr>
+    <tr class="if-no-js-hide table-header-secondary">
+      <td colspan="4">
+        <form>
+          <label for="table-filter" class="rm">Filter policies</label>
+          <input id="table-filter" type="text" class="form-control normal js-filter-table-input" placeholder="Filter policies">
+        </form>
+      </td>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% policies.each do |policy| %>
+      <tr>
+        <td><%= policy.name %></td>
+        <td><%= policy.updated_at.to_s(:govuk_date) %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/policies/new.html.erb
+++ b/app/views/policies/new.html.erb
@@ -4,5 +4,5 @@
   <%= f.text_field :name %>
   <%= f.text_area :description %>
 
-  <button>Save this policy</button>
+  <%= f.buttons(cancel_link: policies_path) %>
 <% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,8 +31,12 @@ module PolicyPublisher
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true
 
+    config.autoload_paths += %W(#{config.root}/lib)
+    config.autoload_paths += Dir["#{config.root}/lib/**/"]
+
     # Better forms
-    config.action_view.default_form_builder = GenericFormBuilder
+    require "admin_form_builder"
+    config.action_view.default_form_builder = AdminFormBuilder
     config.action_view.field_error_proc = proc {|html_tag, _| html_tag }
   end
 end

--- a/features/support/policy_helpers.rb
+++ b/features/support/policy_helpers.rb
@@ -6,7 +6,7 @@ module PolicyHelpers
     fill_in "Name", with: name
     fill_in "Description", with: description
 
-    click_on "Save this policy"
+    click_on "Save"
   end
 
   def check_for_policy(name:)

--- a/lib/admin_form_builder.rb
+++ b/lib/admin_form_builder.rb
@@ -1,0 +1,20 @@
+class AdminFormBuilder < GenericFormBuilder
+  STANDARD_FIELDS.each do |method|
+    define_method(method.to_sym) do |field, *args|
+      options, *args = args
+      options ||= {}
+
+      options[:wrapper_html_options] = {class: "form-group"}.merge(options[:wrapper_html_options] || {})
+      options[:class] = Array(options[:class]) + ["form-control", "input-md-4"]
+
+      super(field, options, *args)
+    end
+  end
+
+  def buttons(options)
+    super(options.merge(
+      button_class: %w( btn btn-success ),
+      cancel_class: %w( btn btn-link )
+    ))
+  end
+end


### PR DESCRIPTION
Changes the policies list to a filterable table:
![screenshot 2015-02-09 15 55 45](https://cloud.githubusercontent.com/assets/109225/6109635/27d8a540-b074-11e4-8583-0cd765ff4411.png)

Encapsulates the admin styleguide into a builder (will be extracted to a gem):
![screenshot 2015-02-09 15 55 30](https://cloud.githubusercontent.com/assets/109225/6109652/3f702fd4-b074-11e4-8436-a9cf919b6c97.png)

Part of https://trello.com/c/44banZNs/1-allow-policies-to-be-created-in-the-policy-publisher