### PR TITLE
Update licence

### DIFF
--- a/LICENCE.txt
+++ b/LICENCE.txt
@@ -1,4 +1,4 @@
-Copyright (C) 2014 HM Government (Government Digital Service)
+Copyright (C) 2015 Crown Copyright (Government Digital Service)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in


### PR DESCRIPTION
As per instructions from @annashipman, the copyright for this project should read "Crown Copyright", not "HM Government".

Update to 2015, as thats when this app was recreated.