### PR TITLE
Publish policy area finders

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,8 @@ gem 'govuk_admin_template', '1.5.1'
 gem 'generic_form_builder', '0.12.0'
 gem 'decent_exposure', '2.3.2'
 
+gem 'gds-api-adapters', '17.5.0'
+
 group :development, :test do
   gem 'byebug'
   gem 'web-console', '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    PriorityQueue (0.1.2)
     actionmailer (4.2.0)
       actionpack (= 4.2.0)
       actionview (= 4.2.0)
@@ -89,6 +90,13 @@ GEM
       railties (>= 3.0.0)
     faraday (0.9.1)
       multipart-post (>= 1.2, < 3)
+    gds-api-adapters (17.5.0)
+      link_header
+      lrucache (~> 0.1.1)
+      null_logger
+      plek
+      rack-cache
+      rest-client (~> 1.6.3)
     gds-sso (10.0.0)
       multi_json (~> 1.0)
       oauth2 (~> 1.0)
@@ -118,8 +126,11 @@ GEM
     kgio (2.9.3)
     launchy (2.4.3)
       addressable (~> 2.3)
+    link_header (0.0.8)
     loofah (2.0.1)
       nokogiri (>= 1.5.9)
+    lrucache (0.1.4)
+      PriorityQueue (~> 0.1.2)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
     mime-types (2.4.3)
@@ -131,6 +142,7 @@ GEM
     multipart-post (2.0.0)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
+    null_logger (0.0.1)
     oauth2 (1.0.0)
       faraday (>= 0.8, < 0.10)
       jwt (~> 1.0)
@@ -154,6 +166,8 @@ GEM
       railties (>= 3.1, < 5.0)
     rack (1.6.0)
     rack-accept (0.4.5)
+      rack (>= 0.4)
+    rack-cache (1.2)
       rack (>= 0.4)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -183,6 +197,8 @@ GEM
       thor (>= 0.18.1, < 2.0)
     raindrops (0.13.0)
     rake (10.4.2)
+    rest-client (1.6.7)
+      mime-types (>= 1.16)
     rspec-core (3.2.0)
       rspec-support (~> 3.2.0)
     rspec-expectations (3.2.0)
@@ -256,6 +272,7 @@ DEPENDENCIES
   database_cleaner
   decent_exposure (= 2.3.2)
   factory_girl_rails
+  gds-api-adapters (= 17.5.0)
   gds-sso (= 10.0.0)
   generic_form_builder (= 0.12.0)
   govuk_admin_template (= 1.5.1)

--- a/app/models/policy_area.rb
+++ b/app/models/policy_area.rb
@@ -1,3 +1,5 @@
+require 'gds_api/publishing_api'
+
 class PolicyArea < ActiveRecord::Base
   validates :name, presence: true, uniqueness: true
   validates :slug, presence: true, uniqueness: true
@@ -6,5 +8,17 @@ class PolicyArea < ActiveRecord::Base
   before_validation on: :create do |policy_area|
     policy_area.slug = policy_area.name.to_s.parameterize
     policy_area.content_id = SecureRandom.uuid
+  end
+
+  after_save :publish_policy_area_finder
+
+private
+  def publish_policy_area_finder
+    attrs = PolicyAreaContentItemPresenter.new(self).exportable_attributes
+    publishing_api.put_content_item(attrs["base_path"], attrs)
+  end
+
+  def publishing_api
+    @publishing_api || PolicyPublisher.services(:publishing_api)
   end
 end

--- a/app/models/policy_area.rb
+++ b/app/models/policy_area.rb
@@ -1,8 +1,10 @@
 class PolicyArea < ActiveRecord::Base
   validates :name, presence: true, uniqueness: true
   validates :slug, presence: true, uniqueness: true
+  validates :content_id, presence: true, uniqueness: true
 
   before_validation on: :create do |policy_area|
     policy_area.slug = policy_area.name.to_s.parameterize
+    policy_area.content_id = SecureRandom.uuid
   end
 end

--- a/app/presenters/policy_area_content_item_presenter.rb
+++ b/app/presenters/policy_area_content_item_presenter.rb
@@ -1,0 +1,78 @@
+class PolicyAreaContentItemPresenter
+
+  def initialize(policy_area)
+    @policy_area = policy_area
+  end
+
+  def exportable_attributes
+    {
+      "base_path" => base_path,
+      "format" => "policy_area",
+      "content_id" => content_id,
+      "title" => title,
+      "description" => description,
+      "public_updated_at" => public_updated_at,
+      "update_type" => "major",
+      "publishing_app" => "policy-publisher",
+      "rendering_app" => "finder-frontend",
+      "routes" => routes,
+      "details" => details,
+      "links" => {
+        "organisations" => [],
+        "topics" => [],
+        "related" => [],
+        "part_of" => [],
+      },
+    }
+  end
+
+private
+  attr_reader :policy_area
+
+  def base_path
+    "/government/policies/#{policy_area.slug}"
+  end
+
+  def content_id
+    policy_area.content_id
+  end
+
+  def title
+    policy_area.name
+  end
+
+  def description
+    ""
+  end
+
+  def public_updated_at
+    policy_area.updated_at
+  end
+
+  def routes
+    [
+      {
+        path: base_path,
+        type: "exact",
+      },
+      {
+        path: "#{base_path}.json",
+        type: "exact",
+      }
+    ]
+  end
+
+  def details
+    {
+      document_noun: "areas",
+      email_signup_enabled: false,
+      filter: {
+        policies: [policy_area.slug]
+      },
+      signup_link: nil,
+      summary: policy_area.description,
+      show_summaries: false,
+      facets: [],
+    }
+  end
+end

--- a/config/initializers/services.rb
+++ b/config/initializers/services.rb
@@ -17,6 +17,5 @@ module PolicyPublisher
   class ServiceNotRegisteredException < Exception; end
 end
 
-## EXAMPLE
-# require 'gds_api/publishing_api'
-# PolicyPublisher.services(:publishing_api, GdsApi::PublishingApi.new(Plek.new.find('publishing-api')))
+require 'gds_api/publishing_api'
+PolicyPublisher.services(:publishing_api, GdsApi::PublishingApi.new(Plek.new.find('publishing-api')))

--- a/db/migrate/20150211152824_add_content_id_to_policy_area.rb
+++ b/db/migrate/20150211152824_add_content_id_to_policy_area.rb
@@ -1,0 +1,6 @@
+class AddContentIdToPolicyArea < ActiveRecord::Migration
+  def change
+    add_column :policy_areas, :content_id, :string
+    add_index :policy_areas, :content_id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150211151548) do
+ActiveRecord::Schema.define(version: 20150211152824) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,8 +22,10 @@ ActiveRecord::Schema.define(version: 20150211151548) do
     t.text     "description"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string   "content_id"
   end
 
+  add_index "policy_areas", ["content_id"], name: "index_policy_areas_on_content_id", unique: true, using: :btree
   add_index "policy_areas", ["name"], name: "index_policy_areas_on_name", unique: true, using: :btree
   add_index "policy_areas", ["slug"], name: "index_policy_areas_on_slug", unique: true, using: :btree
 

--- a/features/policy_areas.feature
+++ b/features/policy_areas.feature
@@ -7,8 +7,10 @@ In order to inform the nation about our government's intentions for a topic.
 Scenario: Creating a policy area
   When I create a policy area called "Climate change"
   Then there should be a policy area called "Climate change"
+  Then a policy area called "Climate change" is published "1" times
 
 Scenario: Editing a policy area
-  Given a policy area exists called "Global warming"
+  Given a published policy area exists called "Global warming"
   When I change the title of policy area "Global warming" to "Climate change"
   Then there should be a policy area called "Climate change"
+  Then a policy area called "Global warming" is published "2" times

--- a/features/step_definitions/policy_area_steps.rb
+++ b/features/step_definitions/policy_area_steps.rb
@@ -1,4 +1,5 @@
-Given(/^a policy area exists called "(.*?)"$/) do |policy_area_name|
+Given(/^a published policy area exists called "(.*?)"$/) do |policy_area_name|
+  stub_publishing_api
   FactoryGirl.create(:policy_area, name: policy_area_name)
 end
 
@@ -9,9 +10,14 @@ When(/^I change the title of policy area "(.*?)" to "(.*?)"$/) do |old_name, new
 end
 
 When(/^I create a policy area called "(.*?)"$/) do |policy_area_name|
+  stub_publishing_api
   create_policy_area(name: policy_area_name)
 end
 
 Then(/^there should be a policy area called "(.*?)"$/) do |policy_area_name|
   check_for_policy_area(name: policy_area_name)
+end
+
+Then(/^a policy area called "(.*?)" is published "(.*?)" times$/) do |policy_area_name, times|
+  check_policy_area_is_published_to_publishing_api("/government/policies/#{policy_area_name.to_s.parameterize}", times.to_i)
 end

--- a/features/support/policy_area_helpers.rb
+++ b/features/support/policy_area_helpers.rb
@@ -1,4 +1,8 @@
+require 'gds_api/test_helpers/publishing_api'
+
 module PolicyHelpers
+  include GdsApi::TestHelpers::PublishingApi
+
   def create_policy_area(name:, description: "A policy_area description")
     visit policy_areas_path
     click_on "Create a policy area"
@@ -23,6 +27,19 @@ module PolicyHelpers
   def check_for_policy_area(name:)
     visit policy_areas_path
     expect(page).to have_content(name)
+  end
+
+  def check_policy_area_is_published_to_publishing_api(base_path, times)
+    assert_publishing_api_put_item(
+      base_path,
+      {
+        "base_path" => base_path,
+        "format" => "policy_area",
+        "rendering_app" => "finder-frontend",
+        "publishing_app" => "policy-publisher",
+      },
+      times,
+    )
   end
 end
 

--- a/features/support/publishing_api_helpers.rb
+++ b/features/support/publishing_api_helpers.rb
@@ -1,0 +1,14 @@
+require "gds_api/test_helpers/publishing_api"
+
+module PublishingAPIHelpers
+  include GdsApi::TestHelpers::PublishingApi
+  def stub_publishing_api
+    stub_default_publishing_api_put
+  end
+
+  def reset_remote_requests
+    WebMock::RequestRegistry.instance.reset!
+  end
+end
+
+World(PublishingAPIHelpers)

--- a/spec/models/policy_area_spec.rb
+++ b/spec/models/policy_area_spec.rb
@@ -1,6 +1,13 @@
 require "rails_helper"
+require 'gds_api/test_helpers/publishing_api'
 
 RSpec.describe PolicyArea do
+  include GdsApi::TestHelpers::PublishingApi
+
+  before do
+    stub_default_publishing_api_put
+  end
+
   it "automatically adds a slug on creation" do
     policy_area = PolicyArea.create!(name: "Climate change")
 
@@ -39,5 +46,20 @@ RSpec.describe PolicyArea do
     new_global_warming = PolicyArea.new(name: "Global warming")
 
     expect(new_global_warming).not_to be_valid
+  end
+
+  it "publishes a Content Item after save" do
+    policy_area = PolicyArea.create!(name: "Climate change")
+    base_path = "/government/policies/#{policy_area.slug}"
+
+    assert_publishing_api_put_item(
+      base_path,
+      {
+        "base_path" => base_path,
+        "format" => "policy_area",
+        "rendering_app" => "finder-frontend",
+        "publishing_app" => "policy-publisher",
+      }
+    )
   end
 end


### PR DESCRIPTION
This PR contains the work which allows Policy Areas to be published to the ContentStore. [Ticket](https://trello.com/c/iUUr2WvV/20-publish-a-policy-area-finder).

This includes:
* adding a `content_id` to the PolicyArea
* add `gds-api-adapters`
* initialize a Publishing API service
* adding a Presenter for the Content Item
* publish the Content Item after the Policy Area is saved