### PR TITLE
Publish finder for programmes

### DIFF
--- a/app/models/concerns/publishable.rb
+++ b/app/models/concerns/publishable.rb
@@ -1,0 +1,26 @@
+require 'gds_api/publishing_api'
+
+module Publishable
+  extend ActiveSupport::Concern
+
+  included do
+    validates :content_id, presence: true, uniqueness: true
+
+    before_validation on: :create do |object|
+      object.slug = object.name.to_s.parameterize
+      object.content_id = SecureRandom.uuid
+    end
+
+    after_save :publish_finder
+  end
+
+private
+  def publish_finder
+    attrs = PolicyAreaContentItemPresenter.new(self).exportable_attributes
+    publishing_api.put_content_item(attrs["base_path"], attrs)
+  end
+
+  def publishing_api
+    @publishing_api ||= PolicyPublisher.services(:publishing_api)
+  end
+end

--- a/app/models/concerns/publishable.rb
+++ b/app/models/concerns/publishable.rb
@@ -11,12 +11,12 @@ module Publishable
       object.content_id = SecureRandom.uuid
     end
 
-    after_save :publish_finder
+    after_save :publish_content_item
   end
 
 private
-  def publish_finder
-    attrs = PolicyAreaContentItemPresenter.new(self).exportable_attributes
+  def publish_content_item
+    attrs = ContentItemPresenter.new(self).exportable_attributes
     publishing_api.put_content_item(attrs["base_path"], attrs)
   end
 

--- a/app/models/policy_area.rb
+++ b/app/models/policy_area.rb
@@ -1,24 +1,10 @@
-require 'gds_api/publishing_api'
-
 class PolicyArea < ActiveRecord::Base
+  include Publishable
+
   validates :name, presence: true, uniqueness: true
   validates :slug, presence: true, uniqueness: true
-  validates :content_id, presence: true, uniqueness: true
 
   before_validation on: :create do |policy_area|
     policy_area.slug = policy_area.name.to_s.parameterize
-    policy_area.content_id = SecureRandom.uuid
-  end
-
-  after_save :publish_policy_area_finder
-
-private
-  def publish_policy_area_finder
-    attrs = PolicyAreaContentItemPresenter.new(self).exportable_attributes
-    publishing_api.put_content_item(attrs["base_path"], attrs)
-  end
-
-  def publishing_api
-    @publishing_api || PolicyPublisher.services(:publishing_api)
   end
 end

--- a/app/models/programme.rb
+++ b/app/models/programme.rb
@@ -1,4 +1,6 @@
 class Programme < ActiveRecord::Base
+  include Publishable
+
   validates :name, presence: true, uniqueness: true
   validates :slug, presence: true, uniqueness: true
 

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -1,7 +1,7 @@
-class PolicyAreaContentItemPresenter
+class ContentItemPresenter
 
-  def initialize(policy_area)
-    @policy_area = policy_area
+  def initialize(policy)
+    @policy = policy
   end
 
   def exportable_attributes
@@ -27,18 +27,18 @@ class PolicyAreaContentItemPresenter
   end
 
 private
-  attr_reader :policy_area
+  attr_reader :policy
 
   def base_path
-    "/government/policies/#{policy_area.slug}"
+    "/government/policies/#{policy.slug}"
   end
 
   def content_id
-    policy_area.content_id
+    policy.content_id
   end
 
   def title
-    policy_area.name
+    policy.name
   end
 
   def description
@@ -46,7 +46,7 @@ private
   end
 
   def public_updated_at
-    policy_area.updated_at
+    policy.updated_at
   end
 
   def routes
@@ -67,10 +67,10 @@ private
       document_noun: "areas",
       email_signup_enabled: false,
       filter: {
-        policies: [policy_area.slug]
+        policies: [policy.slug]
       },
       signup_link: nil,
-      summary: policy_area.description,
+      summary: policy.description,
       show_summaries: false,
       facets: [],
     }

--- a/db/migrate/20150213114023_add_content_id_to_programme.rb
+++ b/db/migrate/20150213114023_add_content_id_to_programme.rb
@@ -1,0 +1,6 @@
+class AddContentIdToProgramme < ActiveRecord::Migration
+  def change
+    add_column :programmes, :content_id, :string
+    add_index :programmes, :content_id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150211152824) do
+ActiveRecord::Schema.define(version: 20150213114023) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -35,8 +35,10 @@ ActiveRecord::Schema.define(version: 20150211152824) do
     t.text     "description"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string   "content_id"
   end
 
+  add_index "programmes", ["content_id"], name: "index_programmes_on_content_id", unique: true, using: :btree
   add_index "programmes", ["name"], name: "index_programmes_on_name", unique: true, using: :btree
   add_index "programmes", ["slug"], name: "index_programmes_on_slug", unique: true, using: :btree
 

--- a/features/programmes.feature
+++ b/features/programmes.feature
@@ -7,8 +7,10 @@ In order to inform the nation about our government's concrete actions for a topi
 Scenario: Creating a programme
   When I create a programme called "CO2 reduction"
   Then there should be a programme called "CO2 reduction"
+  Then a programme called "CO2 reduction" is published "1" times
 
 Scenario: Editing a programme
   Given a programme exists called "CO2 reduction"
   When I change the title of programme "CO2 reduction" to "Carbon credits"
   Then there should be a programme called "Carbon credits"
+  Then a programme called "CO2 reduction" is published "2" times

--- a/features/step_definitions/policy_area_steps.rb
+++ b/features/step_definitions/policy_area_steps.rb
@@ -19,5 +19,5 @@ Then(/^there should be a policy area called "(.*?)"$/) do |policy_area_name|
 end
 
 Then(/^a policy area called "(.*?)" is published "(.*?)" times$/) do |policy_area_name, times|
-  check_policy_area_is_published_to_publishing_api("/government/policies/#{policy_area_name.to_s.parameterize}", times.to_i)
+  check_content_item_is_published_to_publishing_api("/government/policies/#{policy_area_name.to_s.parameterize}", times.to_i)
 end

--- a/features/step_definitions/programme_steps.rb
+++ b/features/step_definitions/programme_steps.rb
@@ -1,4 +1,5 @@
 Given(/^a programme exists called "(.*?)"$/) do |programme_name|
+  stub_publishing_api
   FactoryGirl.create(:programme, name: programme_name)
 end
 
@@ -9,9 +10,14 @@ When(/^I change the title of programme "(.*?)" to "(.*?)"$/) do |old_name, new_n
 end
 
 When(/^I create a programme called "(.*?)"$/) do |programme_name|
+  stub_publishing_api
   create_programme(name: programme_name)
 end
 
 Then(/^there should be a programme called "(.*?)"$/) do |programme_name|
   check_for_programme(name: programme_name)
+end
+
+Then(/^a programme called "(.*?)" is published "(.*?)" times$/) do |policy_area_name, times|
+  check_content_item_is_published_to_publishing_api("/government/policies/#{policy_area_name.to_s.parameterize}", times.to_i)
 end

--- a/features/support/policy_area_helpers.rb
+++ b/features/support/policy_area_helpers.rb
@@ -28,19 +28,6 @@ module PolicyHelpers
     visit policy_areas_path
     expect(page).to have_content(name)
   end
-
-  def check_policy_area_is_published_to_publishing_api(base_path, times)
-    assert_publishing_api_put_item(
-      base_path,
-      {
-        "base_path" => base_path,
-        "format" => "policy_area",
-        "rendering_app" => "finder-frontend",
-        "publishing_app" => "policy-publisher",
-      },
-      times,
-    )
-  end
 end
 
 World(PolicyHelpers)

--- a/features/support/publishing_api_helpers.rb
+++ b/features/support/publishing_api_helpers.rb
@@ -9,6 +9,19 @@ module PublishingAPIHelpers
   def reset_remote_requests
     WebMock::RequestRegistry.instance.reset!
   end
+
+  def check_content_item_is_published_to_publishing_api(base_path, times)
+    assert_publishing_api_put_item(
+      base_path,
+      {
+        "base_path" => base_path,
+        "format" => "policy_area",
+        "rendering_app" => "finder-frontend",
+        "publishing_app" => "policy-publisher",
+      },
+      times,
+    )
+  end
 end
 
 World(PublishingAPIHelpers)


### PR DESCRIPTION
This PR follows the same flow as https://github.com/alphagov/policy-publisher/pull/11 for publishing a Programme to the PublishingAPI and entails:

- refactoring the PublishingAPI interactions (along with the validations and callbacks required) to a concern and using that in the PolicyArea
- rename the PolicyAreaPresenter to ContentItemPresenter and change the reference to `policy_area` to `object`
- add the `content_id` to Programme
- change PublishingAPI test helpers to be more generic
- add the Publishable concern to Programme along with updating the test

[Ticket](https://trello.com/c/iob8yFS6/5-investigate-finder-frontend-rummager-interaction).