### PR TITLE
Send the human readable format in ContentItem

### DIFF
--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -69,10 +69,20 @@ private
       filter: {
         policies: [policy.slug]
       },
+      human_readable_finder_format: human_readable_finder_format,
       signup_link: nil,
       summary: policy.description,
       show_summaries: false,
       facets: [],
     }
+  end
+
+  def human_readable_finder_format
+    case policy
+    when PolicyArea
+      "Policy Area"
+    when Programme
+      "Policy Programme"
+    end
   end
 end

--- a/spec/presenters/content_item_presenter_spec.rb
+++ b/spec/presenters/content_item_presenter_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe ContentItemPresenter do
+
+
+  let(:policy) {
+    PolicyArea.new(
+      name: "Tea and biscuits",
+      slug: "tea-and-biscuits",
+      description: "Tea and biscuits are popular among many people who live in the UK.",
+      content_id: "f61106bd-fb70-4003-a85a-71e5d52bea01",
+    )
+  }
+
+  let(:presenter) { ContentItemPresenter.new(policy) }
+
+  describe "#exportable_attributes" do
+
+    it "has fields required by the ContentStore" do
+      exported_attrs = presenter.exportable_attributes
+      expect(exported_attrs["base_path"]).to eq("/government/policies/#{policy.slug}")
+      expect(exported_attrs["title"]).to eq(policy.name)
+    end
+
+    it "sets details hash" do
+      details = presenter.exportable_attributes["details"]
+
+      expect(details[:filter][:policies]).to match_array([policy.slug])
+      expect(details[:human_readable_finder_format]).to eq("Policy Area")
+    end
+  end
+end

--- a/spec/presenters/content_item_presenter_spec.rb
+++ b/spec/presenters/content_item_presenter_spec.rb
@@ -1,8 +1,6 @@
 require "rails_helper"
 
 RSpec.describe ContentItemPresenter do
-
-
   let(:policy) {
     PolicyArea.new(
       name: "Tea and biscuits",
@@ -15,7 +13,6 @@ RSpec.describe ContentItemPresenter do
   let(:presenter) { ContentItemPresenter.new(policy) }
 
   describe "#exportable_attributes" do
-
     it "has fields required by the ContentStore" do
       exported_attrs = presenter.exportable_attributes
       expect(exported_attrs["base_path"]).to eq("/government/policies/#{policy.slug}")


### PR DESCRIPTION
For Policies, we want to specify if it's a Policy Area or Policy Programme on the page. This commit sends it in the ContentItem which is then passed to the title component as the context which is rendered above the title. 

Example screenshot: 
![screen shot 2015-02-16 at 10 59 03](https://cloud.githubusercontent.com/assets/449004/6210778/e53091ba-b5ca-11e4-96e4-60f2a6971fda.png)
