### PR TITLE
Use sentence case for Finder format name

### DIFF
--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -80,9 +80,9 @@ private
   def human_readable_finder_format
     case policy
     when PolicyArea
-      "Policy Area"
+      "Policy area"
     when Programme
-      "Policy Programme"
+      "Policy programme"
     end
   end
 end

--- a/spec/presenters/content_item_presenter_spec.rb
+++ b/spec/presenters/content_item_presenter_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe ContentItemPresenter do
       details = presenter.exportable_attributes["details"]
 
       expect(details[:filter][:policies]).to match_array([policy.slug])
-      expect(details[:human_readable_finder_format]).to eq("Policy Area")
+      expect(details[:human_readable_finder_format]).to eq("Policy area")
     end
   end
 end


### PR DESCRIPTION
Policy Area and Policy Programme should be sentence case. This commit fixes that.