### PR TITLE
Remove base_path from Publishing API request body

### DIFF
--- a/app/models/concerns/publishable.rb
+++ b/app/models/concerns/publishable.rb
@@ -16,8 +16,9 @@ module Publishable
 
 private
   def publish_content_item
-    attrs = ContentItemPresenter.new(self).exportable_attributes
-    publishing_api.put_content_item(attrs["base_path"], attrs)
+    presenter = ContentItemPresenter.new(self)
+    attrs = presenter.exportable_attributes
+    publishing_api.put_content_item(presenter.base_path, attrs)
   end
 
   def publishing_api

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -6,7 +6,6 @@ class ContentItemPresenter
 
   def exportable_attributes
     {
-      "base_path" => base_path,
       "format" => "policy_area",
       "content_id" => content_id,
       "title" => title,
@@ -26,12 +25,12 @@ class ContentItemPresenter
     }
   end
 
-private
-  attr_reader :policy
-
   def base_path
     "/government/policies/#{policy.slug}"
   end
+
+private
+  attr_reader :policy
 
   def content_id
     policy.content_id

--- a/features/support/publishing_api_helpers.rb
+++ b/features/support/publishing_api_helpers.rb
@@ -14,7 +14,6 @@ module PublishingAPIHelpers
     assert_publishing_api_put_item(
       base_path,
       {
-        "base_path" => base_path,
         "format" => "policy_area",
         "rendering_app" => "finder-frontend",
         "publishing_app" => "policy-publisher",

--- a/spec/models/policy_area_spec.rb
+++ b/spec/models/policy_area_spec.rb
@@ -55,7 +55,6 @@ RSpec.describe PolicyArea do
     assert_publishing_api_put_item(
       base_path,
       {
-        "base_path" => base_path,
         "format" => "policy_area",
         "rendering_app" => "finder-frontend",
         "publishing_app" => "policy-publisher",

--- a/spec/presenters/content_item_presenter_spec.rb
+++ b/spec/presenters/content_item_presenter_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe ContentItemPresenter do
   describe "#exportable_attributes" do
     it "has fields required by the ContentStore" do
       exported_attrs = presenter.exportable_attributes
-      expect(exported_attrs["base_path"]).to eq("/government/policies/#{policy.slug}")
+      expect(exported_attrs["routes"].first[:path]).to eq("/government/policies/#{policy.slug}")
       expect(exported_attrs["title"]).to eq(policy.name)
     end
 


### PR DESCRIPTION
Publishing API currently ignores this field and is about to start rejecting it.
It uses the version in the request URL instead.

Successfully tested in development.

See: https://github.com/alphagov/content-store/pull/104