### PR TITLE
Add rake task for mass publishing

### DIFF
--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -1,0 +1,7 @@
+namespace :publishing_api do
+  desc "Publish all Policies to the Publishing API"
+  task publish_policies: :environment do
+    PolicyArea.all.map(&:save)
+    Programme.all.map(&:save)
+  end
+end


### PR DESCRIPTION
As we continue to iterate on what is sent as part of the ContentItem, we need a way to mass publish all the Policies with the new information. This commit adds a rake task which triggers a save for all PolicyAreas and Programmes, which then publishes them to the PublishingAPI.