### PR TITLE
Add .atom route for Finders

### DIFF
--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -57,6 +57,10 @@ private
       {
         path: "#{base_path}.json",
         type: "exact",
+      },
+      {
+        path: "#{base_path}.atom",
+        type: "exact",
       }
     ]
   end


### PR DESCRIPTION
This commit adds the .atom route to the Finder Content Item. This enables the feeds for each Finder being published through Policy Publisher.