### PR TITLE
Fix document noun typo

### DIFF
--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -63,7 +63,7 @@ private
 
   def details
     {
-      document_noun: "areas",
+      document_noun: "document",
       email_signup_enabled: false,
       filter: {
         policies: [policy.slug]


### PR DESCRIPTION
The document noun was mistakingly set as `areas`. This commit changes it to be `document` which fits when filtering multiple formats.