### PR TITLE
Policies finder & content schemas

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,4 +31,5 @@ group :test do
   gem 'factory_girl_rails'
   gem 'webmock'
   gem 'timecop'
+  gem 'json-schema', '2.5.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,6 +122,8 @@ GEM
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
     json (1.8.2)
+    json-schema (2.5.0)
+      addressable (~> 2.3)
     jwt (1.2.1)
     kgio (2.9.3)
     launchy (2.4.3)
@@ -278,6 +280,7 @@ DEPENDENCIES
   gds-sso (= 10.0.0)
   generic_form_builder (= 0.13.0)
   govuk_admin_template (= 1.5.1)
+  json-schema (= 2.5.0)
   launchy
   pg
   plek (= 1.10.0)

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -11,6 +11,7 @@ class ContentItemPresenter
       "title" => title,
       "description" => description,
       "public_updated_at" => public_updated_at,
+      "locale" => "en",
       "update_type" => "major",
       "publishing_app" => "policy-publisher",
       "rendering_app" => "finder-frontend",

--- a/features/step_definitions/policy_area_steps.rb
+++ b/features/step_definitions/policy_area_steps.rb
@@ -20,4 +20,10 @@ end
 
 Then(/^a policy area called "(.*?)" is published "(.*?)" times$/) do |policy_area_name, times|
   check_content_item_is_published_to_publishing_api("/government/policies/#{policy_area_name.to_s.parameterize}", times.to_i)
+
+  policy_area = PolicyArea.find_by_slug(policy_area_name.to_s.parameterize)
+  assert_valid_against_schema(
+    ContentItemPresenter.new(policy_area).exportable_attributes,
+    "finder"
+  )
 end

--- a/features/step_definitions/programme_steps.rb
+++ b/features/step_definitions/programme_steps.rb
@@ -32,6 +32,12 @@ Then(/^the programme "(.*?)" should be associated with the policy areas "(.*?)" 
   )
 end
 
-Then(/^a programme called "(.*?)" is published "(.*?)" times$/) do |policy_area_name, times|
-  check_content_item_is_published_to_publishing_api("/government/policies/#{policy_area_name.to_s.parameterize}", times.to_i)
+Then(/^a programme called "(.*?)" is published "(.*?)" times$/) do |programme_name, times|
+  check_content_item_is_published_to_publishing_api("/government/policies/#{programme_name.to_s.parameterize}", times.to_i)
+
+  programme = Programme.find_by_slug(programme_name.to_s.parameterize)
+  assert_valid_against_schema(
+    ContentItemPresenter.new(programme).exportable_attributes,
+    "finder"
+  )
 end

--- a/features/support/publishing_api_helpers.rb
+++ b/features/support/publishing_api_helpers.rb
@@ -21,6 +21,11 @@ module PublishingAPIHelpers
       times,
     )
   end
+
+  def assert_valid_against_schema(content_item_hash, format)
+    validator = GovukContentSchema::Validator.new(format, content_item_hash.to_json)
+    validator.valid? || "JSON not valid against #{format} schema: #{validator.errors.to_s}"
+  end
 end
 
 World(PublishingAPIHelpers)

--- a/jenkins-schema.sh
+++ b/jenkins-schema.sh
@@ -1,0 +1,52 @@
+#!/bin/bash -xe
+export DISPLAY=:99
+export GOVUK_APP_DOMAIN=test.alphagov.co.uk
+export GOVUK_ASSET_ROOT=http://static.test.alphagov.co.uk
+env
+
+function github_status {
+  STATUS="$1"
+  MESSAGE="$2"
+  gh-status alphagov/govuk-content-schemas "$SCHEMA_GIT_COMMIT" "$STATUS" -d "Build #${BUILD_NUMBER} ${MESSAGE}" -u "$BUILD_URL" -c "policy publisher contract tests" >/dev/null
+}
+
+function error_handler {
+  trap - ERR # disable error trap to avoid recursion
+  local parent_lineno="$1"
+  local message="$2"
+  local code="${3:-1}"
+  if [[ -n "$message" ]] ; then
+    echo "Error on or near line ${parent_lineno}: ${message}; exiting with status ${code}"
+  else
+    echo "Error on or near line ${parent_lineno}; exiting with status ${code}"
+  fi
+  github_status failure "failed on Jenkins"
+  exit "${code}"
+}
+
+trap "error_handler ${LINENO}" ERR
+github_status pending "is running on Jenkins"
+
+# Ensure there are no artefacts left over from previous builds
+git clean -fdx
+
+# Clone govuk-content-schemas dependency for contract tests
+rm -rf tmp/govuk-content-schemas
+git clone git@github.com:alphagov/govuk-content-schemas.git tmp/govuk-content-schemas
+cd tmp/govuk-content-schemas
+git checkout $SCHEMA_GIT_COMMIT
+cd ../..
+
+time bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
+RAILS_ENV=test GOVUK_CONTENT_SCHEMAS_PATH=tmp/govuk-content-schemas time bundle exec rake
+
+EXIT_STATUS=$?
+echo "EXIT STATUS: $EXIT_STATUS"
+
+if [ "$EXIT_STATUS" == "0" ]; then
+  github_status success "succeeded on Jenkins"
+else
+  github_status failure "failed on Jenkins"
+fi
+
+exit $EXIT_STATUS

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -35,7 +35,13 @@ git merge --no-commit origin/master || git merge --abort
 bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment --without development
 bundle exec rake db:reset
 bundle exec rake assets:clean assets:precompile
-bundle exec cucumber && bundle exec rspec spec/
+
+# Clone govuk-content-schemas depedency for tests
+rm -rf tmp/govuk-content-schemas
+git clone git@github.com:alphagov/govuk-content-schemas.git tmp/govuk-content-schemas
+
+RAILS_ENV=test GOVUK_CONTENT_SCHEMAS_PATH=tmp/govuk-content-schemas bundle exec rake
+
 
 export EXIT_STATUS=$?
 

--- a/lib/govuk_content_schema.rb
+++ b/lib/govuk_content_schema.rb
@@ -1,0 +1,40 @@
+require 'json-schema'
+
+class GovukContentSchema
+
+  class ImproperlyConfiguredError < RuntimeError; end
+
+  VALID_SCHEMA_NAMES = [
+    'finder',
+  ]
+
+  def self.schema_path(schema_name)
+    if VALID_SCHEMA_NAMES.include? schema_name
+      Rails.root.join("#{self.govuk_content_schemas_path}/formats/#{schema_name}/publisher/schema.json").to_s
+    end
+  end
+
+  def self.govuk_content_schemas_path
+    ENV['GOVUK_CONTENT_SCHEMAS_PATH'] || '../govuk-content-schemas'
+  end
+
+  class Validator
+    def initialize(schema_name, data)
+      @schema_path = GovukContentSchema.schema_path(schema_name)
+      if !Pathname(@schema_path).dirname.exist?
+        raise ImproperlyConfiguredError, "Dependency govuk-content-schemas cannot be found. Ensure it is checked out in the same parent directory as this application (see README.md for more details)."
+      elif !File.exists?(@schema_path)
+        raise ImproperlyConfiguredError, "Schema file not found: #{@schema_path}. Mke sure it is present in govuk-content-schemas."
+      end
+      @data = data
+    end
+
+    def valid?
+      errors.empty?
+    end
+
+    def errors
+      @errors ||= JSON::Validator.fully_validate(@schema_path, @data)
+    end
+  end
+end

--- a/lib/policies_finder_publisher.rb
+++ b/lib/policies_finder_publisher.rb
@@ -1,0 +1,74 @@
+require "gds_api/publishing_api"
+
+class PoliciesFinderPublisher
+
+  def publish
+    publishing_api.put_content_item(base_path, exportable_attributes)
+  end
+
+  def exportable_attributes
+    {
+      "base_path" => base_path,
+      "format" => "finder",
+      "content_id" => "d6582d48-df19-46b3-bf84-9157192801a6",
+      "title" => "Policies",
+      "description" => "",
+      "public_updated_at" => public_updated_at,
+      "locale" => "en",
+      "update_type" => "major",
+      "publishing_app" => "policy-publisher",
+      "rendering_app" => "finder-frontend",
+      "routes" => routes,
+      "details" => details,
+      "links" => {
+        "organisations" => [],
+        "topics" => [],
+        "related" => [],
+      },
+    }
+  end
+
+private
+
+  def base_path
+    "/government/policies"
+  end
+
+  def public_updated_at
+    File.mtime(File.dirname(__FILE__))
+  end
+
+  def routes
+    [
+      {
+        path: base_path,
+        type: "exact",
+      },
+      {
+        path: "#{base_path}.json",
+        type: "exact",
+      },
+      {
+        path: "#{base_path}.atom",
+        type: "exact",
+      }
+    ]
+  end
+
+  def details
+    {
+      document_noun: "policy",
+      email_signup_enabled: false,
+      filter: {
+        format: "policy"
+      },
+      show_summaries: false,
+      facets: [],
+    }
+  end
+
+  def publishing_api
+    @publishing_api ||= PolicyPublisher.services(:publishing_api)
+  end
+
+end

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -4,4 +4,11 @@ namespace :publishing_api do
     PolicyArea.all.map(&:save)
     Programme.all.map(&:save)
   end
+
+  desc "Publish the Policies Finder to the Publishing API"
+  task publish_policies_finder: :environment do
+    require "policies_finder_publisher"
+
+    PoliciesFinderPublisher.new.publish
+  end
 end

--- a/spec/lib/policies_finder_publisher_spec.rb
+++ b/spec/lib/policies_finder_publisher_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+RSpec.describe PoliciesFinderPublisher do
+
+  let(:publisher) { described_class.new }
+
+  describe "#exportable_attributes" do
+    it "validates against govuk-content-schema" do
+      attrs = publisher.exportable_attributes
+      validator = GovukContentSchema::Validator.new("finder", attrs.to_json)
+      assert validator.valid?, "JSON not valid against finder schema: #{validator.errors.to_s}"
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a Finder for all Policies which is published when a rake task is ran. It also introduces testing against the content schema for the Finder. [Ticket](https://trello.com/c/liL5l7xi/53-create-a-policy-finder). The commits are as follows:

- add `json-schema` to Gemfile in order to get `JSON::Validator.fully_validate`
- add a rake task and class for PoliciesFinderPublisher
- add the content schema to the existing tests and validate their output
- update `jenkins.sh` to pull the content schemas when running the tests
- add `jenkins-schema-sh` which is ran when `govuk_content_schemas` is updated