### PR TITLE
Policies finder should query by document_type

### DIFF
--- a/lib/policies_finder_publisher.rb
+++ b/lib/policies_finder_publisher.rb
@@ -60,7 +60,7 @@ private
       document_noun: "policy",
       email_signup_enabled: false,
       filter: {
-        format: "policy"
+        document_type: "policy"
       },
       show_summaries: false,
       facets: [],


### PR DESCRIPTION
This commit fixes a typo which was querying by `format`, instead it should be by `document_type`.