### PR TITLE
Ensure that the test database exists for schema tests

### DIFF
--- a/jenkins-schema.sh
+++ b/jenkins-schema.sh
@@ -38,6 +38,7 @@ git checkout $SCHEMA_GIT_COMMIT
 cd ../..
 
 time bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
+RAILS_ENV=test bundle exec rake db:reset
 RAILS_ENV=test GOVUK_CONTENT_SCHEMAS_PATH=tmp/govuk-content-schemas time bundle exec rake
 
 EXIT_STATUS=$?


### PR DESCRIPTION
When the schema tests ran on a node that presumably had never run the tests, they
failed because the database didn't exist: https://ci-new.alphagov.co.uk/job/govuk_policy_publisher_schema_tests/18/console