### PR TITLE
Fix context for polices + other random tweaks

### DIFF
--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -73,20 +73,11 @@ private
       filter: {
         policies: [policy.slug]
       },
-      human_readable_finder_format: human_readable_finder_format,
+      human_readable_finder_format: 'Policy',
       signup_link: nil,
       summary: policy.description,
       show_summaries: false,
       facets: [],
     }
-  end
-
-  def human_readable_finder_format
-    case policy
-    when PolicyArea
-      "Policy area"
-    when Programme
-      "Policy programme"
-    end
   end
 end

--- a/features/policy_areas.feature
+++ b/features/policy_areas.feature
@@ -7,10 +7,10 @@ In order to inform the nation about our government's intentions for a topic.
 Scenario: Creating a policy area
   When I create a policy area called "Climate change"
   Then there should be a policy area called "Climate change"
-  Then a policy area called "Climate change" is published "1" times
+  And a policy area called "Climate change" is published to publishing API
 
 Scenario: Editing a policy area
   Given a published policy area exists called "Global warming"
   When I change the title of policy area "Global warming" to "Climate change"
   Then there should be a policy area called "Climate change"
-  Then a policy area called "Global warming" is published "2" times
+  And a policy area called "Global warming" is published to publishing API

--- a/features/programmes.feature
+++ b/features/programmes.feature
@@ -7,13 +7,13 @@ In order to inform the nation about our government's concrete actions for a topi
 Scenario: Creating a programme
   When I create a programme called "CO2 reduction"
   Then there should be a programme called "CO2 reduction"
-  Then a programme called "CO2 reduction" is published "1" times
+  And a programme called "CO2 reduction" is published to publishing API
 
 Scenario: Editing a programme
   Given a programme exists called "CO2 reduction"
   When I change the title of programme "CO2 reduction" to "Carbon credits"
   Then there should be a programme called "Carbon credits"
-  Then a programme called "CO2 reduction" is published "2" times
+  And a programme called "CO2 reduction" is published to publishing API
 
 Scenario: Associating a programme with policy areas
   Given a policy area exists called "Climate change"

--- a/features/step_definitions/policy_area_steps.rb
+++ b/features/step_definitions/policy_area_steps.rb
@@ -21,10 +21,4 @@ end
 
 Then(/^a policy area called "(.*?)" is published to publishing API$/) do |policy_area_name|
   assert_content_item_is_published_to_publishing_api("/government/policies/#{policy_area_name.to_s.parameterize}")
-
-  policy_area = PolicyArea.find_by_slug(policy_area_name.to_s.parameterize)
-  assert_valid_against_schema(
-    ContentItemPresenter.new(policy_area).exportable_attributes,
-    "finder"
-  )
 end

--- a/features/step_definitions/policy_area_steps.rb
+++ b/features/step_definitions/policy_area_steps.rb
@@ -1,6 +1,7 @@
 Given(/^a (?:published )?policy area exists called "(.*?)"$/) do |policy_area_name|
   stub_publishing_api
   FactoryGirl.create(:policy_area, name: policy_area_name)
+  reset_remote_requests
 end
 
 When(/^I change the title of policy area "(.*?)" to "(.*?)"$/) do |old_name, new_name|
@@ -18,8 +19,8 @@ Then(/^there should be a policy area called "(.*?)"$/) do |policy_area_name|
   check_for_policy_area(name: policy_area_name)
 end
 
-Then(/^a policy area called "(.*?)" is published "(.*?)" times$/) do |policy_area_name, times|
-  check_content_item_is_published_to_publishing_api("/government/policies/#{policy_area_name.to_s.parameterize}", times.to_i)
+Then(/^a policy area called "(.*?)" is published to publishing API$/) do |policy_area_name|
+  assert_content_item_is_published_to_publishing_api("/government/policies/#{policy_area_name.to_s.parameterize}")
 
   policy_area = PolicyArea.find_by_slug(policy_area_name.to_s.parameterize)
   assert_valid_against_schema(

--- a/features/step_definitions/programme_steps.rb
+++ b/features/step_definitions/programme_steps.rb
@@ -1,6 +1,7 @@
 Given(/^a programme exists called "(.*?)"$/) do |programme_name|
   stub_publishing_api
   FactoryGirl.create(:programme, name: programme_name)
+  reset_remote_requests
 end
 
 When(/^I change the title of programme "(.*?)" to "(.*?)"$/) do |old_name, new_name|
@@ -32,8 +33,8 @@ Then(/^the programme "(.*?)" should be associated with the policy areas "(.*?)" 
   )
 end
 
-Then(/^a programme called "(.*?)" is published "(.*?)" times$/) do |programme_name, times|
-  check_content_item_is_published_to_publishing_api("/government/policies/#{programme_name.to_s.parameterize}", times.to_i)
+Then(/^a programme called "(.*?)" is published to publishing API$/) do |programme_name|
+  assert_content_item_is_published_to_publishing_api("/government/policies/#{programme_name.to_s.parameterize}")
 
   programme = Programme.find_by_slug(programme_name.to_s.parameterize)
   assert_valid_against_schema(

--- a/features/step_definitions/programme_steps.rb
+++ b/features/step_definitions/programme_steps.rb
@@ -35,10 +35,4 @@ end
 
 Then(/^a programme called "(.*?)" is published to publishing API$/) do |programme_name|
   assert_content_item_is_published_to_publishing_api("/government/policies/#{programme_name.to_s.parameterize}")
-
-  programme = Programme.find_by_slug(programme_name.to_s.parameterize)
-  assert_valid_against_schema(
-    ContentItemPresenter.new(programme).exportable_attributes,
-    "finder"
-  )
 end

--- a/features/support/publishing_api_helpers.rb
+++ b/features/support/publishing_api_helpers.rb
@@ -10,7 +10,7 @@ module PublishingAPIHelpers
     WebMock::RequestRegistry.instance.reset!
   end
 
-  def check_content_item_is_published_to_publishing_api(base_path, times)
+  def assert_content_item_is_published_to_publishing_api(base_path)
     assert_publishing_api_put_item(
       base_path,
       {
@@ -18,7 +18,6 @@ module PublishingAPIHelpers
         "rendering_app" => "finder-frontend",
         "publishing_app" => "policy-publisher",
       },
-      times,
     )
   end
 

--- a/lib/policies_finder_publisher.rb
+++ b/lib/policies_finder_publisher.rb
@@ -8,7 +8,6 @@ class PoliciesFinderPublisher
 
   def exportable_attributes
     {
-      "base_path" => base_path,
       "format" => "finder",
       "content_id" => "d6582d48-df19-46b3-bf84-9157192801a6",
       "title" => "Policies",

--- a/lib/policies_finder_publisher.rb
+++ b/lib/policies_finder_publisher.rb
@@ -28,7 +28,6 @@ class PoliciesFinderPublisher
       "details" => details,
       "links" => {
         "organisations" => [],
-        "topics" => [],
         "related" => [],
       },
     }

--- a/lib/policies_finder_publisher.rb
+++ b/lib/policies_finder_publisher.rb
@@ -1,5 +1,12 @@
 require "gds_api/publishing_api"
 
+# This is a utility class for publishing the base-finder for policies to the
+# publishing API. This finder lives at /government/policies.
+#
+# A rake task exists to (re-)publish this to Publishing API:
+#
+#   bundle exec rake publish_policies_finder
+#
 class PoliciesFinderPublisher
 
   def publish

--- a/spec/presenters/content_item_presenter_spec.rb
+++ b/spec/presenters/content_item_presenter_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe ContentItemPresenter do
       details = presenter.exportable_attributes["details"]
 
       expect(details[:filter][:policies]).to match_array([policy.slug])
-      expect(details[:human_readable_finder_format]).to eq("Policy area")
+      expect(details[:human_readable_finder_format]).to eq("Policy")
     end
   end
 end


### PR DESCRIPTION
This is mainly a bunch of changes and tweaks I've made whilst trying to get my head around how the policy publisher works. It also delivers on the following story to update the "context" label on the new policies:

https://trello.com/c/hn70UOVH/79-change-context-name-on-policies-programme-areas-to-policy

