### PR TITLE
Verify "policy" format against content schema

### DIFF
--- a/app/models/policy_area.rb
+++ b/app/models/policy_area.rb
@@ -5,4 +5,5 @@ class PolicyArea < ActiveRecord::Base
 
   validates :name, presence: true, uniqueness: true
   validates :slug, presence: true, uniqueness: true
+  validates :description, presence: true
 end

--- a/app/models/programme.rb
+++ b/app/models/programme.rb
@@ -5,6 +5,7 @@ class Programme < ActiveRecord::Base
 
   validates :name, presence: true, uniqueness: true
   validates :slug, presence: true, uniqueness: true
+  validates :description, presence: true
 
   def to_s
     name

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -6,7 +6,7 @@ class ContentItemPresenter
 
   def exportable_attributes
     {
-      "format" => "policy_area",
+      "format" => "policy",
       "content_id" => content_id,
       "title" => title,
       "description" => description,
@@ -19,9 +19,7 @@ class ContentItemPresenter
       "details" => details,
       "links" => {
         "organisations" => [],
-        "topics" => [],
         "related" => [],
-        "part_of" => [],
       },
     }
   end
@@ -74,7 +72,7 @@ private
         policies: [policy.slug]
       },
       human_readable_finder_format: 'Policy',
-      signup_link: nil,
+      signup_link: '',
       summary: policy.description,
       show_summaries: false,
       facets: [],

--- a/features/support/publishing_api_helpers.rb
+++ b/features/support/publishing_api_helpers.rb
@@ -14,7 +14,7 @@ module PublishingAPIHelpers
     assert_publishing_api_put_item(
       base_path,
       {
-        "format" => "policy_area",
+        "format" => "policy",
         "rendering_app" => "finder-frontend",
         "publishing_app" => "policy-publisher",
       },

--- a/features/support/publishing_api_helpers.rb
+++ b/features/support/publishing_api_helpers.rb
@@ -20,11 +20,6 @@ module PublishingAPIHelpers
       },
     )
   end
-
-  def assert_valid_against_schema(content_item_hash, format)
-    validator = GovukContentSchema::Validator.new(format, content_item_hash.to_json)
-    validator.valid? || "JSON not valid against #{format} schema: #{validator.errors.to_s}"
-  end
 end
 
 World(PublishingAPIHelpers)

--- a/lib/govuk_content_schema.rb
+++ b/lib/govuk_content_schema.rb
@@ -6,11 +6,14 @@ class GovukContentSchema
 
   VALID_SCHEMA_NAMES = [
     'finder',
+    'policy'
   ]
 
   def self.schema_path(schema_name)
     if VALID_SCHEMA_NAMES.include? schema_name
       Rails.root.join("#{self.govuk_content_schemas_path}/formats/#{schema_name}/publisher/schema.json").to_s
+    else
+      raise "'#{schema_name}' is not a valid schema name"
     end
   end
 
@@ -24,7 +27,7 @@ class GovukContentSchema
       if !Pathname(@schema_path).dirname.exist?
         raise ImproperlyConfiguredError, "Dependency govuk-content-schemas cannot be found. Ensure it is checked out in the same parent directory as this application (see README.md for more details)."
       elif !File.exists?(@schema_path)
-        raise ImproperlyConfiguredError, "Schema file not found: #{@schema_path}. Mke sure it is present in govuk-content-schemas."
+        raise ImproperlyConfiguredError, "Schema file not found: #{@schema_path}. Make sure it is present in govuk-content-schemas."
       end
       @data = data
     end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -5,9 +5,11 @@ FactoryGirl.define do
 
   factory :policy_area do
     sequence(:name) {|n| "Policy area #{n}" }
+    description "Policy area description"
   end
 
   factory :programme do
     sequence(:name) {|n| "Programme #{n}" }
+    description "Policy programme description"
   end
 end

--- a/spec/lib/policies_finder_publisher_spec.rb
+++ b/spec/lib/policies_finder_publisher_spec.rb
@@ -6,9 +6,7 @@ RSpec.describe PoliciesFinderPublisher do
 
   describe "#exportable_attributes" do
     it "validates against govuk-content-schema" do
-      attrs = publisher.exportable_attributes
-      validator = GovukContentSchema::Validator.new("finder", attrs.to_json)
-      assert validator.valid?, "JSON not valid against finder schema: #{validator.errors.to_s}"
+      assert_valid_against_schema publisher.exportable_attributes.as_json, "finder"
     end
   end
 end

--- a/spec/models/policy_area_spec.rb
+++ b/spec/models/policy_area_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe PolicyArea do
     assert_publishing_api_put_item(
       base_path,
       {
-        "format" => "policy_area",
+        "format" => "policy",
         "rendering_app" => "finder-frontend",
         "publishing_app" => "policy-publisher",
       }

--- a/spec/models/policy_area_spec.rb
+++ b/spec/models/policy_area_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe PolicyArea do
   end
 
   it "automatically adds a slug on creation" do
-    policy_area = PolicyArea.create!(name: "Climate change")
+    policy_area = FactoryGirl.create(:policy_area, name: "Climate change")
 
     expect(policy_area.slug).to eq("climate-change")
   end
@@ -32,24 +32,24 @@ RSpec.describe PolicyArea do
   end
 
   it "enforces unique names" do
-    PolicyArea.create!(name: "Climate change")
-    duplicate_policy_area = PolicyArea.new(name: "Climate change")
+    FactoryGirl.create(:policy_area, name: "Climate change")
+    duplicate_policy_area = FactoryGirl.build(:policy_area, name: "Climate change")
 
     expect(duplicate_policy_area).not_to be_valid
   end
 
   it "enforces unique slugs" do
-    global_warming = PolicyArea.create!(name: "Global warming")
+    global_warming = FactoryGirl.create(:policy_area, name: "Global warming")
     global_warming.name = "Climate change"
     global_warming.save!
 
-    new_global_warming = PolicyArea.new(name: "Global warming")
+    new_global_warming = FactoryGirl.build(:policy_area, name: "Global warming")
 
     expect(new_global_warming).not_to be_valid
   end
 
   it "publishes a Content Item after save" do
-    policy_area = PolicyArea.create!(name: "Climate change")
+    policy_area = FactoryGirl.create(:policy_area, name: "Climate change")
     base_path = "/government/policies/#{policy_area.slug}"
 
     assert_publishing_api_put_item(

--- a/spec/presenters/content_item_presenter_spec.rb
+++ b/spec/presenters/content_item_presenter_spec.rb
@@ -8,17 +8,16 @@ RSpec.describe ContentItemPresenter do
     stub_default_publishing_api_put
   end
 
-  let(:policy) {
-    PolicyArea.create!(
-      name: "Tea and biscuits",
-      description: "Tea and biscuits are popular among many people who live in the UK.",
-    )
-  }
-
-  let(:presenter) { ContentItemPresenter.new(policy) }
-
   describe "#exportable_attributes" do
-    it "validates against the schema for a policy" do
+    it "validates against the schema with a policy area" do
+      presenter = ContentItemPresenter.new(FactoryGirl.create(:policy_area))
+
+      assert_valid_against_schema(presenter.exportable_attributes.as_json, "policy")
+    end
+
+    it "validates against the schema with a policy programme" do
+      presenter = ContentItemPresenter.new(FactoryGirl.create(:programme))
+
       assert_valid_against_schema(presenter.exportable_attributes.as_json, "policy")
     end
   end

--- a/spec/presenters/content_item_presenter_spec.rb
+++ b/spec/presenters/content_item_presenter_spec.rb
@@ -19,8 +19,7 @@ RSpec.describe ContentItemPresenter do
 
   describe "#exportable_attributes" do
     it "validates against the schema for a policy" do
-      validator = GovukContentSchema::Validator.new('policy', presenter.exportable_attributes.as_json)
-      assert validator.valid?, "JSON not valid against the 'policy' schema: #{validator.errors.to_s}"
+      assert_valid_against_schema(presenter.exportable_attributes.as_json, "policy")
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -22,4 +22,9 @@ RSpec.configure do |config|
   # examples within a transaction, remove the following line or assign false
   # instead of true.
   config.use_transactional_fixtures = true
+
+  def assert_valid_against_schema(content_item, format)
+    validator = GovukContentSchema::Validator.new(format, content_item)
+    assert validator.valid?, "JSON not valid against the '#{format}' schema: #{validator.errors.to_s}"
+  end
 end


### PR DESCRIPTION
This ensures policy-publisher is generating a policy that is consistent with the schema in `govuk-content-schemas`.

Build will fail until the schema changes[1] have been merged.

[1] https://github.com/alphagov/govuk-content-schemas/pull/27