### PR TITLE
Publish policies to rummager

### DIFF
--- a/app/models/concerns/publishable.rb
+++ b/app/models/concerns/publishable.rb
@@ -9,11 +9,16 @@ module Publishable
       object.content_id = SecureRandom.uuid
     end
 
-    after_save :publish_content_item
+    after_save :publish!
+  end
+
+  def publish!
+    publish_content_item!
+    publish_rummager_artefact!
   end
 
 private
-  def publish_content_item
+  def publish_content_item!
     presenter = ContentItemPresenter.new(self)
     attrs = presenter.exportable_attributes
     publishing_api.put_content_item(presenter.base_path, attrs)
@@ -21,5 +26,15 @@ private
 
   def publishing_api
     @publishing_api ||= PolicyPublisher.services(:publishing_api)
+  end
+
+  def publish_rummager_artefact!
+    presenter = IndexablePresenter.new(self)
+    attrs = presenter.indexable_attributes
+    rummager.add_document("policy", presenter.id, attrs)
+  end
+
+  def rummager
+    @rummager ||= PolicyPublisher.services(:rummager)
   end
 end

--- a/app/models/concerns/publishable.rb
+++ b/app/models/concerns/publishable.rb
@@ -1,5 +1,3 @@
-require 'gds_api/publishing_api'
-
 module Publishable
   extend ActiveSupport::Concern
 

--- a/app/presenters/indexable_presenter.rb
+++ b/app/presenters/indexable_presenter.rb
@@ -1,0 +1,25 @@
+class IndexablePresenter
+
+  def initialize(policy)
+    @policy = policy
+  end
+
+  def indexable_attributes
+    {
+      title: policy.name,
+      description: policy.description,
+      link: id,
+      indexable_content: "",
+      organisations: [],
+      last_update: policy.updated_at,
+    }
+  end
+
+  def id
+    "/government/policies/#{policy.slug}"
+  end
+
+private
+  attr_reader :policy
+
+end

--- a/config/initializers/services.rb
+++ b/config/initializers/services.rb
@@ -19,3 +19,6 @@ end
 
 require 'gds_api/publishing_api'
 PolicyPublisher.services(:publishing_api, GdsApi::PublishingApi.new(Plek.new.find('publishing-api')))
+
+require 'gds_api/rummager'
+PolicyPublisher.services(:rummager, GdsApi::Rummager.new(Plek.new.find('search')))

--- a/features/policy_areas.feature
+++ b/features/policy_areas.feature
@@ -14,3 +14,4 @@ Scenario: Editing a policy area
   When I change the title of policy area "Global warming" to "Climate change"
   Then there should be a policy area called "Climate change"
   And a policy area called "Global warming" is published to publishing API
+  Then a policy area called "Climate change" is indexed for search

--- a/features/programmes.feature
+++ b/features/programmes.feature
@@ -21,3 +21,4 @@ Scenario: Associating a programme with policy areas
   And a programme exists called "Carbon credits"
   When I associate the programme "Carbon credits" with the policy areas "Climate change" and "UK industry"
   Then the programme "Carbon credits" should be associated with the policy areas "Climate change" and "UK industry"
+  Then a programme called "Carbon credits" is indexed for search

--- a/features/step_definitions/policy_area_steps.rb
+++ b/features/step_definitions/policy_area_steps.rb
@@ -1,5 +1,6 @@
 Given(/^a (?:published )?policy area exists called "(.*?)"$/) do |policy_area_name|
   stub_publishing_api
+  stub_rummager
   FactoryGirl.create(:policy_area, name: policy_area_name)
   reset_remote_requests
 end
@@ -12,6 +13,7 @@ end
 
 When(/^I create a policy area called "(.*?)"$/) do |policy_area_name|
   stub_publishing_api
+  stub_rummager
   create_policy_area(name: policy_area_name)
 end
 
@@ -21,4 +23,9 @@ end
 
 Then(/^a policy area called "(.*?)" is published to publishing API$/) do |policy_area_name|
   assert_content_item_is_published_to_publishing_api("/government/policies/#{policy_area_name.to_s.parameterize}")
+end
+
+Then(/^a policy area called "(.*?)" is indexed for search$/) do |policy_area_name|
+  policy_area = PolicyArea.find_by_name(policy_area_name)
+  assert_policy_published_to_rummager(policy_area)
 end

--- a/features/step_definitions/programme_steps.rb
+++ b/features/step_definitions/programme_steps.rb
@@ -1,5 +1,6 @@
 Given(/^a programme exists called "(.*?)"$/) do |programme_name|
   stub_publishing_api
+  stub_rummager
   FactoryGirl.create(:programme, name: programme_name)
   reset_remote_requests
 end
@@ -12,6 +13,7 @@ end
 
 When(/^I create a programme called "(.*?)"$/) do |programme_name|
   stub_publishing_api
+  stub_rummager
   create_programme(name: programme_name)
 end
 
@@ -35,4 +37,9 @@ end
 
 Then(/^a programme called "(.*?)" is published to publishing API$/) do |programme_name|
   assert_content_item_is_published_to_publishing_api("/government/policies/#{programme_name.to_s.parameterize}")
+end
+
+Then(/^a programme called "(.*?)" is indexed for search$/) do |programme_name|
+  programme = Programme.find_by_name(programme_name)
+  assert_policy_published_to_rummager(programme)
 end

--- a/features/support/rummager_helpers.rb
+++ b/features/support/rummager_helpers.rb
@@ -1,0 +1,28 @@
+require "gds_api/test_helpers/rummager"
+
+module RummagerHelpers
+  include GdsApi::TestHelpers::Rummager
+
+  def stub_rummager
+    stub_any_rummager_post
+  end
+
+  def assert_policy_published_to_rummager(policy)
+    # The block allows the helper compares JSON objects rather
+    # than a hash to JSON
+
+    expected_json = JSON.parse({
+      title: policy.name,
+      description: policy.description,
+      link: "/government/policies/#{policy.slug}",
+      indexable_content: "",
+      organisations: [],
+      last_update: policy.updated_at,
+      _type: "policy",
+      _id: "/government/policies/#{policy.slug}",
+    }.to_json)
+    assert_rummager_posted_item(expected_json)
+  end
+end
+
+World(RummagerHelpers)

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -1,8 +1,8 @@
 namespace :publishing_api do
   desc "Publish all Policies to the Publishing API"
   task publish_policies: :environment do
-    PolicyArea.all.map(&:save)
-    Programme.all.map(&:save)
+    PolicyArea.all.map(&:publish!)
+    Programme.all.map(&:publish!)
   end
 
   desc "Publish the Policies Finder to the Publishing API"

--- a/spec/presenters/content_item_presenter_spec.rb
+++ b/spec/presenters/content_item_presenter_spec.rb
@@ -1,11 +1,14 @@
 require "rails_helper"
 require "gds_api/test_helpers/publishing_api"
+require "gds_api/test_helpers/rummager"
 
 RSpec.describe ContentItemPresenter do
   include GdsApi::TestHelpers::PublishingApi
+  include GdsApi::TestHelpers::Rummager
 
   before do
     stub_default_publishing_api_put
+    stub_any_rummager_post
   end
 
   describe "#exportable_attributes" do


### PR DESCRIPTION
This PR contains the work which sends Policies to Rummager when created. Commits go as follows:
- Cleanup the `Publishable` concern
- Initialise Rummager
- Add an Indexable Presenter
- Send Policies to Rummager and change the `after_save` to be a `#publish` method which publishes the content item and indexable document
- Use the publish item from the rake task

[Ticket](https://trello.com/c/TvQngvWL/70-add-policies-to-rummager).