### PR TITLE
Linking a policy to organisations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem 'generic_form_builder', '0.13.0'
 gem 'select2-rails', '3.5.9.3'
 gem 'decent_exposure', '2.3.2'
 
-gem 'gds-api-adapters', '17.5.0'
+gem 'gds-api-adapters', '18.0.0'
 
 group :development, :test do
   gem 'byebug'

--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem 'generic_form_builder', '0.13.0'
 gem 'select2-rails', '3.5.9.3'
 gem 'decent_exposure', '2.3.2'
 
-gem 'gds-api-adapters', '18.0.0'
+gem 'gds-api-adapters', '18.1.0'
 
 group :development, :test do
   gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,7 +90,7 @@ GEM
       railties (>= 3.0.0)
     faraday (0.9.1)
       multipart-post (>= 1.2, < 3)
-    gds-api-adapters (18.0.0)
+    gds-api-adapters (18.1.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -278,7 +278,7 @@ DEPENDENCIES
   database_cleaner
   decent_exposure (= 2.3.2)
   factory_girl_rails
-  gds-api-adapters (= 18.0.0)
+  gds-api-adapters (= 18.1.0)
   gds-sso (= 10.0.0)
   generic_form_builder (= 0.13.0)
   govuk_admin_template (= 1.5.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,13 +90,13 @@ GEM
       railties (>= 3.0.0)
     faraday (0.9.1)
       multipart-post (>= 1.2, < 3)
-    gds-api-adapters (17.5.0)
+    gds-api-adapters (18.0.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
       plek
       rack-cache
-      rest-client (~> 1.6.3)
+      rest-client (~> 1.7.3)
     gds-sso (10.0.0)
       multi_json (~> 1.0)
       oauth2 (~> 1.0)
@@ -142,6 +142,7 @@ GEM
     multi_test (0.1.1)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
+    netrc (0.10.3)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
     null_logger (0.0.1)
@@ -199,8 +200,9 @@ GEM
       thor (>= 0.18.1, < 2.0)
     raindrops (0.13.0)
     rake (10.4.2)
-    rest-client (1.6.7)
-      mime-types (>= 1.16)
+    rest-client (1.7.3)
+      mime-types (>= 1.16, < 3.0)
+      netrc (~> 0.7)
     rspec-core (3.2.0)
       rspec-support (~> 3.2.0)
     rspec-expectations (3.2.0)
@@ -276,7 +278,7 @@ DEPENDENCIES
   database_cleaner
   decent_exposure (= 2.3.2)
   factory_girl_rails
-  gds-api-adapters (= 17.5.0)
+  gds-api-adapters (= 18.0.0)
   gds-sso (= 10.0.0)
   generic_form_builder (= 0.13.0)
   govuk_admin_template (= 1.5.1)

--- a/app/controllers/policy_areas_controller.rb
+++ b/app/controllers/policy_areas_controller.rb
@@ -1,4 +1,5 @@
 class PolicyAreasController < ApplicationController
+  before_filter :clean_blank_parameters, only: [:create, :update]
   expose(:policy_area, attributes: :policy_area_params)
   expose(:policy_areas)
 
@@ -37,7 +38,16 @@ private
   def policy_area_params
     params.require(:policy_area).permit(
       :name,
-      :description
+      :description,
+      organisation_content_ids: []
     )
+  end
+
+  # Rails includes a hidden field for selects on multi-selects so that a value
+  # gets submitted even when nothing is selected. This results in a blank string
+  # being included in the resulting parameter array. We clean this out to prevent
+  # blank strings being stored.
+  def clean_blank_parameters
+    params[:policy_area][:organisation_content_ids].reject! {|id| id.blank? }
   end
 end

--- a/app/controllers/programmes_controller.rb
+++ b/app/controllers/programmes_controller.rb
@@ -1,4 +1,5 @@
 class ProgrammesController < ApplicationController
+  before_filter :clean_blank_parameters, only: [:create, :update]
   expose(:programme, attributes: :programme_params)
   expose(:programmes)
 
@@ -38,7 +39,16 @@ class ProgrammesController < ApplicationController
     params.require(:programme).permit(
       :name,
       :description,
-      {policy_area_ids: []}
+      policy_area_ids: [],
+      organisation_content_ids: [],
     )
+  end
+
+  # Rails includes a hidden field for selects on multi-selects so that a value
+  # gets submitted even when nothing is selected. This results in a blank string
+  # being included in the resulting parameter array. We clean this out to prevent
+  # blank strings being stored.
+  def clean_blank_parameters
+    params[:programme][:organisation_content_ids].reject! {|id| id.blank? }
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -11,4 +11,10 @@ module ApplicationHelper
       end
     end
   end
+
+  # Data container used to generate the options for an organisations select field
+  def organisations_data_container
+    PolicyPublisher.services(:content_register).organisations.
+      map { |org| [org['title'], org['content_id']] }
+  end
 end

--- a/app/models/policy_area.rb
+++ b/app/models/policy_area.rb
@@ -6,4 +6,6 @@ class PolicyArea < ActiveRecord::Base
   validates :name, presence: true, uniqueness: true
   validates :slug, presence: true, uniqueness: true
   validates :description, presence: true
+
+  serialize :organisation_content_ids, Array
 end

--- a/app/models/policy_area.rb
+++ b/app/models/policy_area.rb
@@ -6,6 +6,4 @@ class PolicyArea < ActiveRecord::Base
   validates :name, presence: true, uniqueness: true
   validates :slug, presence: true, uniqueness: true
   validates :description, presence: true
-
-  serialize :organisation_content_ids, Array
 end

--- a/app/models/programme.rb
+++ b/app/models/programme.rb
@@ -7,8 +7,6 @@ class Programme < ActiveRecord::Base
   validates :slug, presence: true, uniqueness: true
   validates :description, presence: true
 
-  serialize :organisation_content_ids, Array
-
   def to_s
     name
   end

--- a/app/models/programme.rb
+++ b/app/models/programme.rb
@@ -7,6 +7,8 @@ class Programme < ActiveRecord::Base
   validates :slug, presence: true, uniqueness: true
   validates :description, presence: true
 
+  serialize :organisation_content_ids, Array
+
   def to_s
     name
   end

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -36,7 +36,7 @@ private
   end
 
   def organisation_content_ids
-    policy.is_a?(PolicyArea) ? policy.organisation_content_ids : []
+    policy.organisation_content_ids
   end
 
   def title

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -18,7 +18,7 @@ class ContentItemPresenter
       "routes" => routes,
       "details" => details,
       "links" => {
-        "organisations" => [],
+        "organisations" => organisation_content_ids,
         "related" => [],
       },
     }
@@ -33,6 +33,10 @@ private
 
   def content_id
     policy.content_id
+  end
+
+  def organisation_content_ids
+    policy.is_a?(PolicyArea) ? policy.organisation_content_ids : []
   end
 
   def title

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -36,7 +36,7 @@ private
   end
 
   def organisation_content_ids
-    policy.organisation_content_ids
+    policy.organisation_content_ids || []
   end
 
   def title

--- a/app/views/policy_areas/_form.html.erb
+++ b/app/views/policy_areas/_form.html.erb
@@ -9,6 +9,5 @@
           class: 'select2',
           data: { placeholder: 'Choose organisations…' } } %>
 
-
   <%= f.buttons(cancel_link: policy_areas_path) %>
 <% end %>

--- a/app/views/policy_areas/_form.html.erb
+++ b/app/views/policy_areas/_form.html.erb
@@ -2,5 +2,13 @@
   <%= f.text_field :name %>
   <%= f.text_area :description %>
 
+  <%= f.select :organisation_content_ids,
+        organisations_data_container,
+        { label: "Organisations" },
+        { multiple: true,
+          class: 'select2',
+          data: { placeholder: 'Choose organisations…' } } %>
+
+
   <%= f.buttons(cancel_link: policy_areas_path) %>
 <% end %>

--- a/app/views/programmes/_form.html.erb
+++ b/app/views/programmes/_form.html.erb
@@ -2,6 +2,13 @@
   <%= f.text_field :name %>
   <%= f.text_area :description %>
 
+  <%= f.select :organisation_content_ids,
+        organisations_data_container,
+        { label: "Organisations" },
+        { multiple: true,
+          class: 'select2',
+          data: { placeholder: 'Choose organisations…' } } %>
+
   <%= f.select :policy_area_ids,
     options_from_collection_for_select(PolicyArea.order(:name), :id, :name, programme.policy_area_ids),
     {

--- a/config/initializers/services.rb
+++ b/config/initializers/services.rb
@@ -1,3 +1,7 @@
+require 'gds_api/publishing_api'
+require 'gds_api/content_register'
+require 'gds_api/rummager'
+
 module PolicyPublisher
   def self.services(name, service = nil)
     @services ||= {}
@@ -17,8 +21,7 @@ module PolicyPublisher
   class ServiceNotRegisteredException < Exception; end
 end
 
-require 'gds_api/publishing_api'
-PolicyPublisher.services(:publishing_api, GdsApi::PublishingApi.new(Plek.new.find('publishing-api')))
 
-require 'gds_api/rummager'
+PolicyPublisher.services(:publishing_api, GdsApi::PublishingApi.new(Plek.new.find('publishing-api')))
 PolicyPublisher.services(:rummager, GdsApi::Rummager.new(Plek.new.find('search')))
+PolicyPublisher.services(:content_register, GdsApi::ContentRegister.new(Plek.new.find('content-register')))

--- a/config/initializers/services.rb
+++ b/config/initializers/services.rb
@@ -3,25 +3,19 @@ require 'gds_api/content_register'
 require 'gds_api/rummager'
 
 module PolicyPublisher
-  def self.services(name, service = nil)
+  def self.register_service(name, service)
     @services ||= {}
 
-    if service
-      @services[name] = service
-      return true
-    else
-      if @services[name]
-        return @services[name]
-      else
-        raise ServiceNotRegisteredException.new(name)
-      end
-    end
+    @services[name] = service
+  end
+
+  def self.services(name)
+    @services[name] or raise ServiceNotRegisteredException.new(name)
   end
 
   class ServiceNotRegisteredException < Exception; end
 end
 
-
-PolicyPublisher.services(:publishing_api, GdsApi::PublishingApi.new(Plek.new.find('publishing-api')))
-PolicyPublisher.services(:rummager, GdsApi::Rummager.new(Plek.new.find('search')))
-PolicyPublisher.services(:content_register, GdsApi::ContentRegister.new(Plek.new.find('content-register')))
+PolicyPublisher.register_service(:publishing_api, GdsApi::PublishingApi.new(Plek.new.find('publishing-api')))
+PolicyPublisher.register_service(:rummager, GdsApi::Rummager.new(Plek.new.find('search')))
+PolicyPublisher.register_service(:content_register, GdsApi::ContentRegister.new(Plek.new.find('content-register')))

--- a/config/initializers/services.rb
+++ b/config/initializers/services.rb
@@ -18,4 +18,4 @@ end
 
 PolicyPublisher.register_service(:publishing_api, GdsApi::PublishingApi.new(Plek.new.find('publishing-api')))
 PolicyPublisher.register_service(:rummager, GdsApi::Rummager.new(Plek.new.find('search')))
-PolicyPublisher.register_service(:content_register, GdsApi::ContentRegister.new(Plek.new.find('content-register')))
+PolicyPublisher.register_service(:content_register, ContentRegister.new)

--- a/db/migrate/20150312125646_add_organisation_content_ids_to_policy_areas.rb
+++ b/db/migrate/20150312125646_add_organisation_content_ids_to_policy_areas.rb
@@ -1,0 +1,5 @@
+class AddOrganisationContentIdsToPolicyAreas < ActiveRecord::Migration
+  def change
+    add_column :policy_areas, :organisation_content_ids, :text
+  end
+end

--- a/db/migrate/20150312125646_add_organisation_content_ids_to_policy_areas.rb
+++ b/db/migrate/20150312125646_add_organisation_content_ids_to_policy_areas.rb
@@ -1,5 +1,5 @@
 class AddOrganisationContentIdsToPolicyAreas < ActiveRecord::Migration
   def change
-    add_column :policy_areas, :organisation_content_ids, :text
+    add_column :policy_areas, :organisation_content_ids, :text, array: true
   end
 end

--- a/db/migrate/20150312162639_add_organisation_content_ids_to_programmes.rb
+++ b/db/migrate/20150312162639_add_organisation_content_ids_to_programmes.rb
@@ -1,0 +1,5 @@
+class AddOrganisationContentIdsToProgrammes < ActiveRecord::Migration
+  def change
+    add_column :programmes, :organisation_content_ids, :text
+  end
+end

--- a/db/migrate/20150312162639_add_organisation_content_ids_to_programmes.rb
+++ b/db/migrate/20150312162639_add_organisation_content_ids_to_programmes.rb
@@ -1,5 +1,5 @@
 class AddOrganisationContentIdsToProgrammes < ActiveRecord::Migration
   def change
-    add_column :programmes, :organisation_content_ids, :text
+    add_column :programmes, :organisation_content_ids, :text, array: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150312125646) do
+ActiveRecord::Schema.define(version: 20150312162639) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -44,6 +44,7 @@ ActiveRecord::Schema.define(version: 20150312125646) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "content_id"
+    t.text     "organisation_content_ids"
   end
 
   add_index "programmes", ["content_id"], name: "index_programmes_on_content_id", unique: true, using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150213144805) do
+ActiveRecord::Schema.define(version: 20150312125646) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,6 +23,7 @@ ActiveRecord::Schema.define(version: 20150213144805) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "content_id"
+    t.text     "organisation_content_ids"
   end
 
   add_index "policy_areas", ["content_id"], name: "index_policy_areas_on_content_id", unique: true, using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -23,7 +23,7 @@ ActiveRecord::Schema.define(version: 20150312162639) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "content_id"
-    t.text     "organisation_content_ids"
+    t.text     "organisation_content_ids", array: true
   end
 
   add_index "policy_areas", ["content_id"], name: "index_policy_areas_on_content_id", unique: true, using: :btree
@@ -44,7 +44,7 @@ ActiveRecord::Schema.define(version: 20150312162639) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "content_id"
-    t.text     "organisation_content_ids"
+    t.text     "organisation_content_ids", array: true
   end
 
   add_index "programmes", ["content_id"], name: "index_programmes_on_content_id", unique: true, using: :btree

--- a/features/policy_areas.feature
+++ b/features/policy_areas.feature
@@ -15,3 +15,8 @@ Scenario: Editing a policy area
   Then there should be a policy area called "Climate change"
   And a policy area called "Global warming" is published to publishing API
   Then a policy area called "Climate change" is indexed for search
+
+Scenario: Associating a policy area with an organisation
+  Given a policy area exists called "Global warming"
+  When I associate the policy area with an organisation
+  Then the policy area should be linked to the organisation when published to publishing API

--- a/features/programmes.feature
+++ b/features/programmes.feature
@@ -22,3 +22,8 @@ Scenario: Associating a programme with policy areas
   When I associate the programme "Carbon credits" with the policy areas "Climate change" and "UK industry"
   Then the programme "Carbon credits" should be associated with the policy areas "Climate change" and "UK industry"
   Then a programme called "Carbon credits" is indexed for search
+
+Scenario: Associating a programme with an organisation
+  Given a programme exists called "Carbon credits"
+  When I associate the programme with an organisation
+  Then the programme should be linked to the organisation when published to publishing API

--- a/features/step_definitions/policy_area_steps.rb
+++ b/features/step_definitions/policy_area_steps.rb
@@ -18,11 +18,7 @@ When(/^I create a policy area called "(.*?)"$/) do |policy_area_name|
 end
 
 When(/^I associate the policy area with an organisation$/) do
-  visit policy_areas_path
-  click_on @policy_area.name
-
-  select 'Organisation 1', from: "Organisations"
-  click_on "Save"
+  associate_policy_area_with_organisation(@policy_area, 'Organisation 1')
 end
 
 Then(/^there should be a policy area called "(.*?)"$/) do |policy_area_name|

--- a/features/step_definitions/programme_steps.rb
+++ b/features/step_definitions/programme_steps.rb
@@ -18,11 +18,7 @@ When(/^I create a programme called "(.*?)"$/) do |programme_name|
 end
 
 When(/^I associate the programme with an organisation$/) do
-  visit programmes_path
-  click_on @programme.name
-
-  select 'Organisation 2', from: 'Organisations'
-  click_on 'Save'
+    associate_programme_with_organisation(programme: @programme, organisation_name: 'Organisation 2')
 end
 
 Then(/^there should be a programme called "(.*?)"$/) do |programme_name|

--- a/features/support/content_register_helpers.rb
+++ b/features/support/content_register_helpers.rb
@@ -1,0 +1,53 @@
+require 'gds_api/test_helpers/content_register'
+
+Before do
+  mock_content_register
+end
+
+module ContentRegisterHelpers
+  include GdsApi::TestHelpers::ContentRegister
+
+  def mock_content_register
+    stub_content_register_entries("organisation", [organisation_1, organisation_2])
+    stub_content_register_entries("person", [person_1, person_2])
+  end
+
+  def organisation_1
+    @organisation_1 ||= {
+      "content_id" => SecureRandom.uuid,
+      "format" => "organisation",
+      "title" => "Organisation 1",
+      "base_path" => "/government/organisations/organisation-1",
+    }
+  end
+
+  def organisation_2
+    @organisation_2 ||= {
+      "content_id" => SecureRandom.uuid,
+      "format" => "organisation",
+      "title" => "Organisation 2",
+      "base_path" => "/government/organisations/organisation-2",
+    }
+  end
+
+  def person_1
+    @person_1 ||= {
+      "content_id" => SecureRandom.uuid,
+      "format" => "person",
+      "title" => "A Person",
+      "base_path" => "/government/organisations/a-person",
+    }
+  end
+
+
+  def person_2
+    @person_2 ||= {
+      "content_id" => SecureRandom.uuid,
+      "format" => "person",
+      "title" => "Another Person",
+      "base_path" => "/government/organisations/another-person",
+    }
+  end
+end
+
+World(ContentRegisterHelpers)

--- a/features/support/policy_area_helpers.rb
+++ b/features/support/policy_area_helpers.rb
@@ -28,6 +28,14 @@ module PolicyHelpers
     visit policy_areas_path
     expect(page).to have_content(name)
   end
+
+  def associate_policy_area_with_organisation(policy_area, organisation_name)
+    visit policy_areas_path
+    click_on policy_area.name
+
+    select organisation_name, from: "Organisations"
+    click_on "Save"
+  end
 end
 
 World(PolicyHelpers)

--- a/features/support/programme_helpers.rb
+++ b/features/support/programme_helpers.rb
@@ -47,6 +47,14 @@ module ProgrammeHelpers
       end
     end
   end
+
+  def associate_programme_with_organisation(programme:, organisation_name:)
+    visit programmes_path
+    click_on programme.name
+
+    select organisation_name, from: "Organisations"
+    click_on "Save"
+  end
 end
 
 World(ProgrammeHelpers)

--- a/lib/content_register.rb
+++ b/lib/content_register.rb
@@ -1,0 +1,16 @@
+class ContentRegister
+  def initialize
+    @api_adapter = GdsApi::ContentRegister.new(Plek.new.find('content-register'))
+  end
+
+  def organisations
+    api_adapter.entries('organisation').to_a
+  end
+
+  def people
+    api_adapter.entries('person').to_a
+  end
+
+private
+  attr_reader :api_adapter
+end

--- a/spec/lib/content_register_spec.rb
+++ b/spec/lib/content_register_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+require 'gds_api/test_helpers/content_register'
+
+RSpec.describe ContentRegister do
+  include GdsApi::TestHelpers::ContentRegister
+
+  before do
+    stub_content_register_entries("organisation", [org_1, org_2])
+    stub_content_register_entries("person", [person])
+  end
+
+  let(:org_1) do
+    {
+      "content_id" => SecureRandom.uuid,
+      "format" => "organisation",
+      "title" => "Organisation 1",
+      "base_path" => "/government/organisations/organisation-1",
+    }
+  end
+
+  let(:org_2) do
+    {
+      "content_id" => SecureRandom.uuid,
+      "format" => "organisation",
+      "title" => "Organisation 2",
+      "base_path" => "/government/organisations/organisation-2",
+    }
+  end
+
+  let(:person) do
+    {
+      "content_id" => SecureRandom.uuid,
+      "format" => "person",
+      "title" => "A Person",
+      "base_path" => "/government/organisations/a-person",
+    }
+  end
+
+  describe "#organisation" do
+    it "returns all entries for the 'organisation' format" do
+      expect(ContentRegister.new.organisations).to eq([org_1, org_2])
+    end
+  end
+
+  describe "#people" do
+    it "returns all entries for the 'person' format" do
+      expect(ContentRegister.new.people).to eql([person])
+    end
+  end
+end

--- a/spec/presenters/content_item_presenter_spec.rb
+++ b/spec/presenters/content_item_presenter_spec.rb
@@ -24,10 +24,18 @@ RSpec.describe ContentItemPresenter do
       assert_valid_against_schema(presenter.exportable_attributes.as_json, "policy")
     end
 
-    it "includes linked organisations" do
+    it "includes linked organisations with a policy area" do
       content_id = SecureRandom.uuid
       policy_area = FactoryGirl.create(:policy_area, organisation_content_ids: [content_id])
       attributes = ContentItemPresenter.new(policy_area).exportable_attributes.as_json
+
+      expect(attributes["links"]["organisations"]).to eq([content_id])
+    end
+
+    it "includes linked organisations with a policy programme" do
+      content_id = SecureRandom.uuid
+      programme = FactoryGirl.create(:programme, organisation_content_ids: [content_id])
+      attributes = ContentItemPresenter.new(programme).exportable_attributes.as_json
 
       expect(attributes["links"]["organisations"]).to eq([content_id])
     end

--- a/spec/presenters/content_item_presenter_spec.rb
+++ b/spec/presenters/content_item_presenter_spec.rb
@@ -23,5 +23,13 @@ RSpec.describe ContentItemPresenter do
 
       assert_valid_against_schema(presenter.exportable_attributes.as_json, "policy")
     end
+
+    it "includes linked organisations" do
+      content_id = SecureRandom.uuid
+      policy_area = FactoryGirl.create(:policy_area, organisation_content_ids: [content_id])
+      attributes = ContentItemPresenter.new(policy_area).exportable_attributes.as_json
+
+      expect(attributes["links"]["organisations"]).to eq([content_id])
+    end
   end
 end


### PR DESCRIPTION
This adds the ability to tag policies to organisations. 

The details for the available organisations are loaded from the Content Register. Any organisations associated with an organisation are included in the "links" for the policy.

Lots of duplication in the code for policy areas and policy programmes. An effort needs to be made to refactor these to reduce duplication and unify their behaviour. Suggesting that be done in a separate pull request.

Story: https://trello.com/c/cZ7P1VfR/51-add-ability-to-tag-policies-to-orgs-and-people