### PR TITLE
Bump govuk-content-schema-test-helpers to 1.0.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,5 +31,5 @@ group :test do
   gem 'factory_girl_rails'
   gem 'webmock'
   gem 'timecop'
-  gem 'govuk-content-schema-test-helpers', '1.0.1'
+  gem 'govuk-content-schema-test-helpers', '1.0.2'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,7 +111,7 @@ GEM
       multi_json (~> 1.3)
     globalid (0.3.0)
       activesupport (>= 4.1.0)
-    govuk-content-schema-test-helpers (1.0.1)
+    govuk-content-schema-test-helpers (1.0.2)
       json-schema (~> 2.5.1)
     govuk_admin_template (1.5.1)
       bootstrap-sass (~> 3.3.3)
@@ -281,7 +281,7 @@ DEPENDENCIES
   gds-api-adapters (= 17.5.0)
   gds-sso (= 10.0.0)
   generic_form_builder (= 0.13.0)
-  govuk-content-schema-test-helpers (= 1.0.1)
+  govuk-content-schema-test-helpers (= 1.0.2)
   govuk_admin_template (= 1.5.1)
   launchy
   pg


### PR DESCRIPTION
This fixes a deprecation warning from RSpec:
<pre>
`failure_message_for_should` is deprecated. Use `failure_message` instead
</pre>