### PR TITLE
Show the SHA of the current release in the footer

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -37,4 +37,6 @@
   <%= yield :extra_javascript %>
 <% end %>
 
+<% content_for :footer_version do %><%= CURRENT_RELEASE_SHA %><% end %>
+
 <%= render template: 'layouts/govuk_admin_template' %>

--- a/config/initializers/current_release_sha.rb
+++ b/config/initializers/current_release_sha.rb
@@ -1,0 +1,6 @@
+if File.exists?("#{Rails.root}/REVISION")
+  revision = `cat #{Rails.root}/REVISION`.chomp
+  CURRENT_RELEASE_SHA = revision[0..10] # Just get the short SHA
+else
+  CURRENT_RELEASE_SHA = "development"
+end


### PR DESCRIPTION
This mirrors the behaviour in other admin app, eg:
- https://github.com/search?q=CURRENT_RELEASE_SHA+%40alphagov&type=Code

`REVISION` is set by Capistrano during deployment.