### PR TITLE
Use slugs for referencing policies

### DIFF
--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -78,7 +78,7 @@ private
       document_noun: "document",
       email_signup_enabled: false,
       filter: {
-        policies: [policy.content_id]
+        policies: [policy.slug]
       },
       human_readable_finder_format: 'Policy',
       signup_link: '',

--- a/lib/search_indexer.rb
+++ b/lib/search_indexer.rb
@@ -14,7 +14,7 @@ class SearchIndexer
       title: policy.name,
       description: policy.description,
       link: policy.base_path,
-      content_id: policy.content_id,
+      slug: policy.slug,
       indexable_content: "",
       organisations: [],
       last_update: policy.updated_at,

--- a/spec/presenters/content_item_presenter_spec.rb
+++ b/spec/presenters/content_item_presenter_spec.rb
@@ -24,6 +24,16 @@ RSpec.describe ContentItemPresenter do
       expect(presenter.exportable_attributes.as_json).to be_valid_against_schema('policy')
     end
 
+    it "includes an appropriate filter to filter by the policy slug" do
+      policy = FactoryGirl.create(:policy_area)
+      presenter = ContentItemPresenter.new(policy)
+      filter = {
+        "policies" => [policy.slug]
+      }
+
+      expect(presenter.exportable_attributes.as_json['details']["filter"]).to eq(filter)
+    end
+
     it "includes linked organisations with a policy area" do
       content_id = SecureRandom.uuid
       policy_area = FactoryGirl.create(:policy_area, organisation_content_ids: [content_id])


### PR DESCRIPTION
The slug for the policy is sent to rummager so that it can be used for filter-based searches. It is also included in the filter for the finder in the details hash sent to content store.

Trello: https://trello.com/c/h2t4VlGE/31-allow-documents-in-whitehall-to-be-tagged-to-new-policy-areas 