### PR TITLE
Add is_historic and government name as metadata

### DIFF
--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -84,7 +84,22 @@ private
       signup_link: '',
       summary: policy.description,
       show_summaries: false,
-      facets: [],
+      facets: facets,
     }
+  end
+
+  def facets
+    [
+      {
+        key: "is_historic",
+        display_as_result_metadata: true,
+        filterable: false,
+      },
+      {
+        key: "government_name",
+        display_as_result_metadata: true,
+        filterable: false,
+      }
+    ]
   end
 end


### PR DESCRIPTION
In order for Finder Frontend to request `is_historic` and `government_name` from Rummager, they need to be added as metadata in the facets array to the Content Item. [Ticket](:https://trello.com/c/uw3FYUyO/119-implement-visual-presentation-of-history-mode-appearance-in-policy-finder).

Requires https://github.com/alphagov/govuk-content-schemas/pull/39 to be merged first.

- [ ] merge https://github.com/alphagov/govuk-content-schemas/pull/39