### PR TITLE
Publish Related Links on policies

### DIFF
--- a/app/models/concerns/publishable.rb
+++ b/app/models/concerns/publishable.rb
@@ -12,6 +12,11 @@ module Publishable
     after_save :publish!
   end
 
+  def republish!
+    publish_content_item!('minor')
+    add_to_search_index!
+  end
+
   def publish!
     publish_content_item!
     add_to_search_index!
@@ -22,8 +27,8 @@ module Publishable
   end
 
 private
-  def publish_content_item!
-    presenter = ContentItemPresenter.new(self)
+  def publish_content_item!(update_type='major')
+    presenter = ContentItemPresenter.new(self, update_type)
     attrs = presenter.exportable_attributes
     publishing_api.put_content_item(base_path, attrs)
   end

--- a/app/models/programme.rb
+++ b/app/models/programme.rb
@@ -8,7 +8,13 @@ class Programme < ActiveRecord::Base
   validates :slug, presence: true, uniqueness: true
   validates :description, presence: true
 
+  after_save :republish_parents!
+
   def to_s
     name
+  end
+
+  def republish_parents!
+    policy_areas.each(&:republish!)
   end
 end

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -1,7 +1,8 @@
 class ContentItemPresenter
 
-  def initialize(policy)
+  def initialize(policy, update_type='major')
     @policy = policy
+    @update_type = update_type
   end
 
   def exportable_attributes
@@ -12,7 +13,7 @@ class ContentItemPresenter
       "description" => description,
       "public_updated_at" => public_updated_at,
       "locale" => "en",
-      "update_type" => "major",
+      "update_type" => update_type,
       "publishing_app" => "policy-publisher",
       "rendering_app" => "finder-frontend",
       "routes" => routes,
@@ -30,7 +31,7 @@ class ContentItemPresenter
   end
 
 private
-  attr_reader :policy
+  attr_reader :policy, :update_type
 
   def content_id
     policy.content_id

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -21,7 +21,7 @@ class ContentItemPresenter
       "links" => {
         "organisations" => organisation_content_ids,
         "people" => people_content_ids,
-        "related" => [],
+        "related" => related,
       },
     }
   end
@@ -116,5 +116,13 @@ private
 
   def inapplicable_nations
     policy.possible_nations - policy.applicable_nations || []
+  end
+
+  def related
+    if policy.respond_to?(:programmes)
+      policy.programmes.map(&:content_id)
+    else
+      []
+    end
   end
 end

--- a/features/programmes.feature
+++ b/features/programmes.feature
@@ -21,7 +21,8 @@ Scenario: Associating a programme with policy areas
   And a programme exists called "Carbon credits"
   When I associate the programme "Carbon credits" with the policy areas "Climate change" and "UK industry"
   Then the programme "Carbon credits" should be associated with the policy areas "Climate change" and "UK industry"
-  Then a programme called "Carbon credits" is indexed for search
+  And the policy area called "Climate change" is republished with a related link to the programme "Carbon credits"
+  And a programme called "Carbon credits" is indexed for search
 
 Scenario: Associating a programme with an organisation
   Given a programme exists called "Carbon credits"

--- a/features/step_definitions/programme_steps.rb
+++ b/features/step_definitions/programme_steps.rb
@@ -52,6 +52,26 @@ Then(/^a programme called "(.*?)" is indexed for search$/) do |programme_name|
   assert_policy_published_to_rummager(programme)
 end
 
+Then(/^the policy area called "(.*?)" is republished with a related link to the programme "(.*?)"$/) do |policy_area_name, programme_name|
+  programme = Programme.find_by_name(programme_name)
+  policy_area = PolicyArea.find_by_name(policy_area_name)
+  assert_publishing_api_put_item(
+    policy_area.base_path,
+    {
+      "format" => "policy",
+      "rendering_app" => "finder-frontend",
+      "publishing_app" => "policy-publisher",
+      "locale" => "en",
+      "update_type" => "minor",
+      "links" => {
+        "organisations" => [],
+        "people" => [],
+        "related" => [programme["content_id"]],
+      },
+    }
+  )
+end
+
 Then(/^the programme should be linked to the organisation when published to publishing API$/) do
   assert_publishing_api_put_item(
     @programme.base_path,

--- a/spec/presenters/content_item_presenter_spec.rb
+++ b/spec/presenters/content_item_presenter_spec.rb
@@ -96,5 +96,15 @@ RSpec.describe ContentItemPresenter do
       expect(nation_applicability["alternative_policies"].first["nation"]).to eq("northern_ireland")
       expect(nation_applicability["alternative_policies"].first["alt_policy_url"]).to eq("https://www.example.ni")
     end
+
+    it "appropriately sets the update type" do
+      content_id = SecureRandom.uuid
+      programme = FactoryGirl.create(:programme, organisation_content_ids: [content_id])
+      major_attributes = ContentItemPresenter.new(programme).exportable_attributes.as_json
+      minor_attributes = ContentItemPresenter.new(programme, update_type='minor').exportable_attributes.as_json
+
+      expect(major_attributes["update_type"]).to eq("major")
+      expect(minor_attributes["update_type"]).to eq("minor")
+    end
   end
 end


### PR DESCRIPTION
When you associate a programme to policy area republish those policy
areas to the content store. Do this as a minor update so that the
updates don't appear in any feeds or email alerts. This will let us
link the programmes in the related links hash.