### PR TITLE
Signup pages

### DIFF
--- a/app/models/policy.rb
+++ b/app/models/policy.rb
@@ -2,6 +2,7 @@ class Policy < ActiveRecord::Base
   validates :content_id, presence: true, uniqueness: true
   validates :name, :slug, presence: true, uniqueness: true
   validates :description, presence: true
+  validates :email_alert_signup_content_id, presence: true, uniqueness: true
 
   validate :applicable_to_at_least_one_nation
   validate :alternative_urls_are_valid
@@ -15,6 +16,7 @@ class Policy < ActiveRecord::Base
   before_validation on: :create do |object|
     object.slug = object.name.to_s.parameterize
     object.content_id = SecureRandom.uuid
+    object.email_alert_signup_content_id = SecureRandom.uuid
   end
 
   scope :areas, -> { joins("LEFT OUTER JOIN policy_relations

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -7,21 +7,21 @@ class ContentItemPresenter
 
   def exportable_attributes
     {
-      "format" => "policy",
-      "content_id" => content_id,
-      "title" => title,
-      "description" => description,
-      "public_updated_at" => public_updated_at,
-      "locale" => "en",
-      "update_type" => update_type,
-      "publishing_app" => "policy-publisher",
-      "rendering_app" => "finder-frontend",
-      "routes" => routes,
-      "details" => details,
-      "links" => {
-        "organisations" => organisation_content_ids,
-        "people" => people_content_ids,
-        "related" => related,
+      format: "policy",
+      content_id: content_id,
+      title: title,
+      description: description,
+      public_updated_at: public_updated_at,
+      locale: "en",
+      update_type: update_type,
+      publishing_app: "policy-publisher",
+      rendering_app: "finder-frontend",
+      routes: routes,
+      details: details,
+      links: {
+        organisations: organisation_content_ids,
+        people: people_content_ids,
+        related: related,
       },
     }
   end

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -22,6 +22,7 @@ class ContentItemPresenter
         organisations: organisation_content_ids,
         people: people_content_ids,
         related: related,
+        email_alert_signup: email_alert_signup_content_id,
       },
     }
   end
@@ -43,6 +44,10 @@ private
 
   def people_content_ids
     policy.people_content_ids || []
+  end
+
+  def email_alert_signup_content_id
+    [policy.email_alert_signup_content_id]
   end
 
   def title

--- a/app/presenters/email_alert_signup_content_item_presenter.rb
+++ b/app/presenters/email_alert_signup_content_item_presenter.rb
@@ -1,0 +1,68 @@
+class EmailAlertSignupContentItemPresenter
+
+  def initialize(policy, update_type="major")
+    @policy = policy
+    @update_type = update_type
+  end
+
+  def exportable_attributes
+    {
+      format: "email_alert_signup",
+      content_id: policy.email_alert_signup_content_id,
+      title: policy.name,
+      description: description,
+      public_updated_at: policy.updated_at.iso8601,
+      locale: "en",
+      update_type: update_type,
+      publishing_app: "policy-publisher",
+      rendering_app: "email-alert-frontend",
+      routes: routes,
+      details: details,
+      links: {},
+    }
+  end
+
+private
+  attr_reader :policy, :update_type
+
+  def base_path
+    "#{policy.base_path}/email-signup"
+  end
+
+  def public_updated_at
+    policy.updated_at
+  end
+
+  def routes
+    [
+      {
+        path: base_path,
+        type: "exact",
+      },
+    ]
+  end
+
+  def details
+    {
+      breadcrumbs: [breadcrumbs],
+      tags: {
+        policy: [policy.slug],
+      },
+    }
+  end
+
+  def description
+    %q[
+      You'll get an email each time a document about
+      this policy is published or updated.
+    ]
+  end
+
+  def breadcrumbs
+    {
+      title: policy.name,
+      link: policy.base_path,
+    }
+  end
+
+end

--- a/app/presenters/email_alert_signup_content_item_presenter.rb
+++ b/app/presenters/email_alert_signup_content_item_presenter.rb
@@ -10,8 +10,8 @@ class EmailAlertSignupContentItemPresenter
       format: "email_alert_signup",
       content_id: policy.email_alert_signup_content_id,
       title: policy.name,
-      description: description,
-      public_updated_at: policy.updated_at.iso8601,
+      description: "",
+      public_updated_at: public_updated_at,
       locale: "en",
       update_type: update_type,
       publishing_app: "policy-publisher",
@@ -22,12 +22,12 @@ class EmailAlertSignupContentItemPresenter
     }
   end
 
-private
-  attr_reader :policy, :update_type
-
   def base_path
     "#{policy.base_path}/email-signup"
   end
+
+private
+  attr_reader :policy, :update_type
 
   def public_updated_at
     policy.updated_at
@@ -44,14 +44,15 @@ private
 
   def details
     {
-      breadcrumbs: [breadcrumbs],
+      breadcrumbs: breadcrumbs,
+      summary: summary,
       tags: {
         policy: [policy.slug],
       },
     }
   end
 
-  def description
+  def summary
     %q[
       You'll get an email each time a document about
       this policy is published or updated.
@@ -59,10 +60,12 @@ private
   end
 
   def breadcrumbs
-    {
-      title: policy.name,
-      link: policy.base_path,
-    }
+    [
+      {
+        title: policy.name,
+        link: policy.base_path,
+      }
+    ]
   end
 
 end

--- a/db/migrate/20150421092720_add_email_alert_signup_content_id_to_policies.rb
+++ b/db/migrate/20150421092720_add_email_alert_signup_content_id_to_policies.rb
@@ -1,0 +1,6 @@
+class AddEmailAlertSignupContentIdToPolicies < ActiveRecord::Migration
+  def change
+    add_column :policies, :email_alert_signup_content_id, :string
+    add_index :policies, :email_alert_signup_content_id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -21,20 +21,22 @@ ActiveRecord::Schema.define(version: 20150423092901) do
     t.string   "name"
     t.text     "description"
     t.string   "content_id"
-    t.text     "organisation_content_ids",    default: [],                array: true
-    t.text     "people_content_ids",          default: [],                array: true
-    t.boolean  "england",                     default: true
+    t.text     "organisation_content_ids",      default: [],                array: true
+    t.text     "people_content_ids",            default: [],                array: true
+    t.boolean  "england",                       default: true
     t.string   "england_policy_url"
-    t.boolean  "northern_ireland",            default: true
+    t.boolean  "northern_ireland",              default: true
     t.string   "northern_ireland_policy_url"
-    t.boolean  "scotland",                    default: true
+    t.boolean  "scotland",                      default: true
     t.string   "scotland_policy_url"
-    t.boolean  "wales",                       default: true
+    t.boolean  "wales",                         default: true
     t.string   "wales_policy_url"
-    t.datetime "created_at",                                 null: false
-    t.datetime "updated_at",                                 null: false
+    t.datetime "created_at",                                   null: false
+    t.datetime "updated_at",                                   null: false
+    t.string   "email_alert_signup_content_id"
   end
 
+  add_index "policies", ["email_alert_signup_content_id"], name: "index_policies_on_email_alert_signup_content_id", unique: true, using: :btree
   add_index "policies", ["name"], name: "index_policies_on_name", using: :btree
 
   create_table "policy_relations", force: :cascade do |t|

--- a/features/policies.feature
+++ b/features/policies.feature
@@ -8,6 +8,7 @@ Scenario: Creating a policy
   When I create a policy called "Climate change"
   Then there should be a policy called "Climate change"
   And a policy called "Climate change" is published to publishing API
+  And an email alert signup page for a policy called "Climate change" is published to publishing API
   And a policy called "Climate change" is indexed for search
 
 Scenario: Editing a policy
@@ -15,6 +16,7 @@ Scenario: Editing a policy
   When I change the title of policy "Global warming" to "Climate change"
   Then there should be a policy called "Climate change"
   And a policy called "Climate change" is published to publishing API
+  And an email alert signup page for a policy called "Climate change" is published to publishing API
   And a policy called "Climate change" is indexed for search
 
 Scenario: Creating a policy programme that is part of another

--- a/features/step_definitions/policy_steps.rb
+++ b/features/step_definitions/policy_steps.rb
@@ -74,6 +74,7 @@ Then(/^the policy should be linked to the organisation when published to publish
         "organisations" => [organisation_1["content_id"]],
         "people" => [],
         "related" => [],
+        "email_alert_signup" => [@policy.email_alert_signup_content_id],
       },
     }
   )
@@ -91,6 +92,7 @@ Then(/^the policy should be linked to the person when published to publishing AP
         "organisations" => [],
         "people" => [person_1["content_id"]],
         "related" => [],
+        "email_alert_signup" => [@policy.email_alert_signup_content_id],
       },
     }
   )

--- a/features/step_definitions/policy_steps.rb
+++ b/features/step_definitions/policy_steps.rb
@@ -52,6 +52,10 @@ Then(/^a policy called "(.*?)" is republished to publishing API$/) do |policy_na
   assert_content_item_is_republished_to_publishing_api(policy.base_path)
 end
 
+Then(/^an email alert signup page for a policy called "(.*?)" is published to publishing API$/) do |policy_name|
+  policy = Policy.find_by(name: policy_name)
+  assert_email_alert_signup_content_item_is_republished_to_publishing_api(policy.base_path)
+end
 
 Then(/^a policy called "(.*?)" is indexed for search$/) do |policy_name|
   policy = Policy.find_by_name(policy_name)

--- a/features/support/publishing_api_helpers.rb
+++ b/features/support/publishing_api_helpers.rb
@@ -28,6 +28,17 @@ module PublishingAPIHelpers
       },
     )
   end
+
+  def assert_email_alert_signup_content_item_is_republished_to_publishing_api(policy_base_path)
+    assert_publishing_api_put_item(
+      "#{policy_base_path}/email-signup",
+      {
+        "format" => "email_alert_signup",
+        "rendering_app" => "email-alert-frontend",
+        "publishing_app" => "policy-publisher",
+      },
+    )
+  end
 end
 
 World(PublishingAPIHelpers)

--- a/lib/policy_actions/email_alert_signup_content_item_publisher.rb
+++ b/lib/policy_actions/email_alert_signup_content_item_publisher.rb
@@ -1,0 +1,22 @@
+# Publishes an email alert signup content item to the Publishing API
+class EmailAlertSignupContentItemPublisher
+  attr_reader :policy
+
+  def initialize(policy)
+    @policy = policy
+  end
+
+  def run!
+    publishing_api.put_content_item(content_item_payload.base_path, content_item_payload.exportable_attributes)
+  end
+
+  def content_item_payload
+    EmailAlertSignupContentItemPresenter.new(policy, 'major')
+  end
+
+private
+
+  def publishing_api
+    @publishing_api ||= PolicyPublisher.services(:publishing_api)
+  end
+end

--- a/lib/publisher.rb
+++ b/lib/publisher.rb
@@ -32,7 +32,7 @@ private
 
   def publish_actions
     if PolicyPublisher.future_policies_enabled?
-      [ContentItemPublisher, ParentPolicyContentItemRepublisher, SearchIndexer]
+      [ContentItemPublisher, EmailAlertSignupContentItemPublisher, ParentPolicyContentItemRepublisher, SearchIndexer]
     else
       [PlaceholderContentItemPublisher]
     end

--- a/spec/presenters/content_item_presenter_spec.rb
+++ b/spec/presenters/content_item_presenter_spec.rb
@@ -49,6 +49,13 @@ RSpec.describe ContentItemPresenter do
       expect(attributes["links"]["related"]).to eq([related_policy.content_id])
     end
 
+    it "includes the linked email alert signup" do
+      policy = FactoryGirl.create(:policy)
+      attributes = ContentItemPresenter.new(policy).exportable_attributes.as_json
+
+      expect(attributes["links"]["email_alert_signup"]).to eq([policy.email_alert_signup_content_id])
+    end
+
     it "doesn't add nation_applicability if the policy applies to all nations" do
       policy = FactoryGirl.create(:policy)
       attributes = ContentItemPresenter.new(policy).exportable_attributes.as_json

--- a/spec/presenters/email_alert_signup_content_item_presenter_spec.rb
+++ b/spec/presenters/email_alert_signup_content_item_presenter_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+RSpec.describe EmailAlertSignupContentItemPresenter do
+  describe "#exportable_attributes" do
+    it "validates against the email alert signup schema" do
+      presenter = EmailAlertSignupContentItemPresenter.new(FactoryGirl.create(:policy))
+
+      expect(presenter.exportable_attributes.as_json).to be_valid_against_schema('email_alert_signup')
+    end
+
+    it "includes appropriate tags to get the subscriptions URL" do
+      policy = FactoryGirl.create(:policy)
+      presenter = EmailAlertSignupContentItemPresenter.new(policy)
+      tags = {
+        "policy" => [policy.slug]
+      }
+
+      expect(presenter.exportable_attributes.as_json['details']["tags"]).to eq(tags)
+    end
+
+    it "includes breadcrumbs with the relevant policy" do
+      policy = FactoryGirl.create(:policy)
+      presenter = EmailAlertSignupContentItemPresenter.new(policy)
+      breadcrumbs = [
+        {
+          "title" => policy.name,
+          "link" => policy.base_path
+        }
+      ]
+
+      expect(presenter.exportable_attributes.as_json['details']["breadcrumbs"]).to eq(breadcrumbs)
+    end
+
+    it "allows the update type to be overridden" do
+      policy = FactoryGirl.create(:policy)
+      major_attributes = EmailAlertSignupContentItemPresenter.new(policy).exportable_attributes.as_json
+      minor_attributes = EmailAlertSignupContentItemPresenter.new(policy, update_type='minor').exportable_attributes.as_json
+
+      expect(major_attributes["update_type"]).to eq("major")
+      expect(minor_attributes["update_type"]).to eq("minor")
+    end
+  end
+end


### PR DESCRIPTION
This PR contains the work which allows Policy Publisher to publish the content item for an Email Alert Signup page relating to the policy and associate it with the Policy Content Item. I've added an `EmailAlertContentItemPresenter` and Publisher following the existing pattern. The Content Item matches the [schema](https://github.com/alphagov/govuk-content-schemas/blob/master/formats/email_alert_signup/publisher/schema.json). This work has been done based on the Frontend code in https://github.com/alphagov/email-alert-frontend/pull/1.

I've also refactored the `ContentItemPresenter` based on our styleguide.