### PR TITLE
Index orgs and people for policies

### DIFF
--- a/app/models/policy.rb
+++ b/app/models/policy.rb
@@ -51,6 +51,18 @@ class Policy < ActiveRecord::Base
     possible_nations - applicable_nations
   end
 
+  def organisations
+    @organisations ||= PolicyPublisher.services(:content_register).organisations.select do |org|
+      organisation_content_ids.include?(org["content_id"])
+    end
+  end
+
+  def people
+    @people ||= PolicyPublisher.services(:content_register).people.select do |org|
+      people_content_ids.include?(org["content_id"])
+    end
+  end
+
 private
 
   def applicable_to_at_least_one_nation

--- a/lib/policy_actions/search_indexer.rb
+++ b/lib/policy_actions/search_indexer.rb
@@ -17,7 +17,8 @@ class SearchIndexer
       link: policy.base_path,
       slug: policy.slug,
       indexable_content: "",
-      organisations: [],
+      organisations: get_slugs(policy.organisations),
+      people: get_slugs(policy.people),
       last_update: policy.updated_at,
     }
   end
@@ -25,5 +26,9 @@ class SearchIndexer
 private
   def rummager
     @rummager ||= PolicyPublisher.services(:rummager)
+  end
+
+  def get_slugs(content_register_items)
+    content_register_items.map {|cri| cri["base_path"].gsub(%r{.*/([^/]+?)$}, '\1') }
   end
 end

--- a/spec/lib/policy_actions/search_indexer_spec.rb
+++ b/spec/lib/policy_actions/search_indexer_spec.rb
@@ -1,15 +1,56 @@
 require "rails_helper"
 require 'gds_api/test_helpers/rummager'
+require 'gds_api/test_helpers/content_register'
 
 RSpec.describe SearchIndexer do
   include GdsApi::TestHelpers::Rummager
+  include GdsApi::TestHelpers::ContentRegister
 
   before do
     stub_any_rummager_post
+    stub_content_register_entries("organisation", organisations)
+    stub_content_register_entries("person", people)
+  end
+
+  let(:organisations) do
+    [
+      {
+        "content_id" => SecureRandom.uuid,
+        "format" => "organisation",
+        "title" => "Organisation 1",
+        "base_path" => "/government/organisations/organisation-1",
+      },
+      {
+        "content_id" => SecureRandom.uuid,
+        "format" => "organisation",
+        "title" => "Organisation 2",
+        "base_path" => "/government/organisations/organisation-2",
+      },
+    ]
+  end
+
+  let(:people) do
+    [
+      {
+        "content_id" => SecureRandom.uuid,
+        "format" => "person",
+        "title" => "Person 1",
+        "base_path" => "/government/organisations/person-1",
+      },
+      {
+        "content_id" => SecureRandom.uuid,
+        "format" => "person",
+        "title" => "Person 2",
+        "base_path" => "/government/organisations/person-2",
+      },
+    ]
   end
 
   it "indexes a a policy with rummager" do
-    policy = FactoryGirl.create(:policy)
+    policy = FactoryGirl.create(:policy,
+      organisation_content_ids: organisations.map {|o| o["content_id"] },
+      people_content_ids: people.map {|person| person["content_id"] }
+    )
     indexer = SearchIndexer.new(policy)
 
     expected_json = {
@@ -18,7 +59,8 @@ RSpec.describe SearchIndexer do
       link: policy.base_path,
       slug: policy.slug,
       indexable_content: "",
-      organisations: [],
+      organisations: ["organisation-1", "organisation-2"],
+      people: ["person-1", "person-2"],
       last_update: policy.updated_at,
       _type: "policy",
       _id: policy.base_path,


### PR DESCRIPTION
Send the slugs of associated organisations and people when indexing policies.

This is needed for https://trello.com/c/RuReu0tZ/50-policies-on-org-homepages and https://trello.com/c/07dhHmwK/58-policies-on-ministers-pages