### PR TITLE
Seed Policies with email_alert_signup_content_id

### DIFF
--- a/db/migrate/20150423111425_seed_policies_with_email_alert_signup_content_id.rb
+++ b/db/migrate/20150423111425_seed_policies_with_email_alert_signup_content_id.rb
@@ -1,0 +1,8 @@
+class SeedPoliciesWithEmailAlertSignupContentId < ActiveRecord::Migration
+  def change
+    Policy.all.each do |policy|
+      policy.email_alert_signup_content_id = SecureRandom.uuid
+      policy.save!
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150423092901) do
+ActiveRecord::Schema.define(version: 20150423111425) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
This commit adds a migration to seed the Policies with a content_id for their matching email_alert_signup content items.