### PR TITLE
Use FeatureFlag model rather than using ENV vars

### DIFF
--- a/app/models/feature_flag.rb
+++ b/app/models/feature_flag.rb
@@ -1,0 +1,14 @@
+class FeatureFlag < ActiveRecord::Base
+  def self.set(key, value)
+    flag = find_by!(key: key)
+    flag.update(enabled: value)
+  end
+
+  def self.enabled?(name)
+    if flag = find_by(key: name)
+      flag.enabled
+    else
+      false
+    end
+  end
+end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -39,7 +39,4 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
-
-  # Turn on temporary feature-flag for future-policies feature during tests
-  ENV['ENABLE_FUTURE_POLICIES'] = '1'
 end

--- a/config/initializers/feature_flags.rb
+++ b/config/initializers/feature_flags.rb
@@ -1,6 +1,0 @@
-module PolicyPublisher
-  # Signifies whether policies should be published live to GOV.UK or not.
-  def self.future_policies_enabled?
-    !!ENV['ENABLE_FUTURE_POLICIES']
-  end
-end

--- a/db/migrate/20150424083442_create_feature_flags.rb
+++ b/db/migrate/20150424083442_create_feature_flags.rb
@@ -1,0 +1,10 @@
+class CreateFeatureFlags < ActiveRecord::Migration
+  def change
+    create_table :feature_flags do |t|
+      t.string :key, unique: true
+      t.boolean :enabled, default: false
+    end
+
+    FeatureFlag.create(key: 'future_policies')
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150423111425) do
+ActiveRecord::Schema.define(version: 20150424083442) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "feature_flags", force: :cascade do |t|
+    t.string  "key"
+    t.boolean "enabled"
+  end
 
   create_table "policies", force: :cascade do |t|
     t.string   "slug"

--- a/features/policies.feature
+++ b/features/policies.feature
@@ -1,3 +1,4 @@
+@future-policies
 Feature: Policy creation
 
 As a content editor

--- a/features/support/future_policies.rb
+++ b/features/support/future_policies.rb
@@ -1,0 +1,5 @@
+# Turn on temporary feature-flag for future-policies feature during selected tests
+# As it's stored in the database it will be wiped after every test anyway
+Before("@future-policies") do
+  FeatureFlag.create(key: 'future_policies', enabled: true)
+end

--- a/lib/publisher.rb
+++ b/lib/publisher.rb
@@ -31,7 +31,7 @@ class Publisher
 private
 
   def publish_actions
-    if PolicyPublisher.future_policies_enabled?
+    if FeatureFlag.enabled?('future_policies')
       [ContentItemPublisher, EmailAlertSignupContentItemPublisher, ParentPolicyContentItemRepublisher, SearchIndexer]
     else
       [PlaceholderContentItemPublisher]

--- a/lib/tasks/feature_flag.rake
+++ b/lib/tasks/feature_flag.rake
@@ -1,0 +1,6 @@
+namespace :feature_flag do
+  desc "sets a feature flag"
+  task :set, [:key, :value] => :environment do |t, args|
+    FeatureFlag.set(args[:key], args[:value])
+  end
+end

--- a/spec/lib/publisher_spec.rb
+++ b/spec/lib/publisher_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe Publisher do
     stub_default_publishing_api_put
     allow(SearchIndexer).to receive(:new).with(policy).and_return(indexer)
     allow(indexer).to receive(:run!)
+
+    FeatureFlag.create(key: 'future_policies', enabled: true)
   end
 
   context "when publishing a policy" do
@@ -66,13 +68,8 @@ RSpec.describe Publisher do
     let(:policy) { FactoryGirl.create(:policy) }
     let!(:rummager_request) { stub_any_rummager_post }
 
-    around do |example|
-      flag_value = ENV.delete('ENABLE_FUTURE_POLICIES')
-      example.run
-      ENV['ENABLE_FUTURE_POLICIES'] = flag_value
-    end
-
     before do
+      FeatureFlag.set('future_policies', false)
       Publisher.new(policy).publish!
     end
 

--- a/spec/models/feature_flag_spec.rb
+++ b/spec/models/feature_flag_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe FeatureFlag do
+  it "isn't enabled by default" do
+    expect(FeatureFlag.enabled?('undefined-key')).to be(false)
+  end
+
+  it "is enabled when set" do
+    FeatureFlag.create(key: 'new-key', enabled: true)
+    expect(FeatureFlag.enabled?('new-key')).to be(true)
+  end
+
+  it "sets the value of a flag" do
+    FeatureFlag.create(key: 'set-key')
+    FeatureFlag.set('set-key', true)
+    expect(FeatureFlag.enabled?('set-key')).to be(true)
+    FeatureFlag.set('set-key', false)
+    expect(FeatureFlag.enabled?('set-key')).to be(false)
+  end
+end


### PR DESCRIPTION
We want to be able to change feature flags without having the need to
update the puppet or deployment repos. The current approach of using ENV
variables would require this.

Created a feature flag module which can take a name and a boolean value
and a rake task to update those feature flags.

If you want to update one you can call:

    bundle exec rake feature_flag:set[new-key,true]