### PR TITLE
Remove email_signup_enabled from content item

### DIFF
--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -82,7 +82,6 @@ private
   def details
     details = {
       document_noun: "document",
-      email_signup_enabled: false,
       filter: {
         policies: [policy.slug]
       },

--- a/lib/policies_finder_publisher.rb
+++ b/lib/policies_finder_publisher.rb
@@ -63,7 +63,6 @@ private
   def details
     {
       document_noun: "policy",
-      email_signup_enabled: false,
       filter: {
         document_type: "policy"
       },


### PR DESCRIPTION
As we now base this off the presence of the link, we can remove this
from the Content Item being created for the Policy and Policies Finder.