### PR TITLE
Add new metadata facets to published schemas

### DIFF
--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -137,7 +137,29 @@ private
         key: "government_name",
         display_as_result_metadata: true,
         filterable: false,
-      }
+      },
+      {
+        key: "public_timestamp",
+        short_name: "Updated",
+        type: "date",
+        display_as_result_metadata: true,
+        filterable: false
+      },
+      {
+        key: "organisations",
+        short_name: "From",
+        type: "text",
+        display_as_result_metadata: true,
+        result_metadata_name_key: "title",
+        filterable: false
+      },
+      {
+        key: "display_type",
+        short_name: "Type",
+        type: "text",
+        display_as_result_metadata: true,
+        filterable: false
+      },
     ]
   end
 end


### PR DESCRIPTION
This adds the orgs, updated at, and document type metadata to
each search result, to match the metadata shown on current
policy document lits, eg, https://www.gov.uk/government/policies/fulfilling-the-commitments-of-the-armed-forces-covenant/activity

- Content schemas examples updated: https://github.com/alphagov/govuk-content-schemas/pull/55
- Finder frontend support for new metadata: https://github.com/alphagov/finder-frontend/pull/191