### PR TITLE
Add date-filtering to policy-finder schema

### DIFF
--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -141,9 +141,10 @@ private
       {
         key: "public_timestamp",
         short_name: "Updated",
+        name: "Published",
         type: "date",
         display_as_result_metadata: true,
-        filterable: false
+        filterable: true
       },
       {
         key: "organisations",


### PR DESCRIPTION
Filtering documents by date is useful, and used in most finders. 
This will add it to all policy finders.

'Published' is consistent with the naming in existing WH document
filters, even if it is a little at odds with updated. WH document
filters avoid this by not visibly labelling the date, which you
can't do with finders yet.

Schema examples updated in https://github.com/alphagov/govuk-content-schemas/pull/56