### PR TITLE
Upgrade govuk-content-schema-test-helpers to 1.3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,6 @@ group :test do
   gem 'factory_girl_rails'
   gem 'webmock'
   gem 'timecop'
-  gem 'govuk-content-schema-test-helpers', '1.0.2'
+  gem 'govuk-content-schema-test-helpers', '1.3.0'
   gem "poltergeist", "1.5.0"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,7 +112,7 @@ GEM
       multi_json (~> 1.3)
     globalid (0.3.0)
       activesupport (>= 4.1.0)
-    govuk-content-schema-test-helpers (1.0.2)
+    govuk-content-schema-test-helpers (1.3.0)
       json-schema (~> 2.5.1)
     govuk_admin_template (1.5.1)
       bootstrap-sass (~> 3.3.3)
@@ -290,7 +290,7 @@ DEPENDENCIES
   gds-api-adapters (= 18.1.0)
   gds-sso (= 10.0.0)
   generic_form_builder (= 0.13.0)
-  govuk-content-schema-test-helpers (= 1.0.2)
+  govuk-content-schema-test-helpers (= 1.3.0)
   govuk_admin_template (= 1.5.1)
   launchy
   pg


### PR DESCRIPTION
We want to [change the directory structure inside govuk-content-schemas](https://github.com/alphagov/govuk-content-schemas/pull/60). The
test helpers encapsulate the directory structure, but we still need to bump the
gem to a version which works with the new (and old) structure.