### PR TITLE
Add updates and org facets to finder-of-finders

### DIFF
--- a/lib/policies_finder_publisher.rb
+++ b/lib/policies_finder_publisher.rb
@@ -67,8 +67,28 @@ private
         document_type: "policy"
       },
       show_summaries: false,
-      facets: [],
+      facets: facets,
     }
+  end
+
+  def facets
+    [
+      {
+        key: "public_timestamp",
+        short_name: "Updated",
+        name: "Published",
+        type: "date",
+        display_as_result_metadata: true,
+        filterable: true
+      },
+      {
+        key: "organisations",
+        short_name: "From",
+        type: "text",
+        display_as_result_metadata: true,
+        filterable: false
+      },
+    ]
   end
 
   def publishing_api


### PR DESCRIPTION
These will be displayed on /government/policies/, so
a user can tell how recently a policy was updated and the
orgs its associated with.

Also adds option to filter by date updated

![image](https://cloud.githubusercontent.com/assets/63201/7497715/3e6c9238-f414-11e4-89b0-670885fca1e3.png)

https://trello.com/c/JDN44MlE/230-metadata-on-finder-of-finders