### PR TITLE
Remove an unused facet field for policy format

### DIFF
--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -151,7 +151,6 @@ private
         short_name: "From",
         type: "text",
         display_as_result_metadata: true,
-        result_metadata_name_key: "title",
         filterable: false
       },
       {


### PR DESCRIPTION
This was accidentally added, it's original purpose was to describe
which key would be used for an object field in a rummager result.

Instead this was handled in finder-frontend itself, but didn't get
removed here.