### PR TITLE
Publish policies in reverse alphabetical order

### DIFF
--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -1,7 +1,7 @@
 namespace :publishing_api do
-  desc "Publish all Policies to the Publishing API"
+  desc "Publish all Policies to the Publishing API in reverse alphabetical order"
   task publish_policies: :environment do
-    Policy.all.each { |policy| Publisher.new(policy).publish! }
+    Policy.all.order("name DESC").each { |policy| Publisher.new(policy).publish! }
   end
 
   desc "Publish the Policies Finder to the Publishing API"


### PR DESCRIPTION
We want the policies to initially appear in alphabetical order. By publishing them in reverse alphabetical order, we ensure they appear in alphabetical order in the finder (most recently published appears at the top)