### PR TITLE
Fix database config to match production naming

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -12,11 +12,11 @@ default: &default
 
 development:
   <<: *default
-  database: policy_publisher_development
+  database: policy-publisher_development 
 
 test: &test
   <<: *default
-  database: policy_publisher_test
+  database: policy-publisher_test
 
 cucumber:
   <<: *test


### PR DESCRIPTION
Production DB uses the prefix `policy-publisher`, which is
convention for most of our apps, in puppet, [deployment](https://github.gds/gds/alphagov-deployment/blob/master/policy-publisher/to_upload/config/production/database.yml#L7) etc.

The typo here meant the sync of the production DB wasn't
replacing the right DB locally.

CC @elliotcm, @tekin, @edds, @tommyp - once this is merged you may need to run a DB sync to get the correctly named (prod) table.

