### PR TITLE
Add current organisations to filter options

### DIFF
--- a/lib/policies_finder_publisher.rb
+++ b/lib/policies_finder_publisher.rb
@@ -86,7 +86,10 @@ private
         short_name: "From",
         type: "text",
         display_as_result_metadata: true,
-        filterable: false
+        filterable: true,
+        allowed_values: allowed_organisation_values,
+        preposition: "from",
+        name: "Organisation",
       },
     ]
   end
@@ -95,4 +98,22 @@ private
     @publishing_api ||= PolicyPublisher.services(:publishing_api)
   end
 
+  def allowed_organisation_values
+    allowed_orgs = organiastions_used_by_policies.map do |org|
+      { label: org["title"], value: org["base_path"].split('/').last }
+    end
+    allowed_orgs.sort_by {|org| org[:label]}
+  end
+
+  def organiastions_used_by_policies
+    PolicyPublisher.services(:content_register).organisations.select do |org|
+      all_organisation_content_ids.include?(org["content_id"])
+    end
+  end
+
+  def all_organisation_content_ids
+    @all_organisation_content_ids ||= Policy.all.map do |policy|
+      policy.organisation_content_ids
+    end.flatten.uniq
+  end
 end

--- a/spec/lib/policies_finder_publisher_spec.rb
+++ b/spec/lib/policies_finder_publisher_spec.rb
@@ -1,6 +1,21 @@
 require "rails_helper"
+require 'gds_api/test_helpers/content_register'
 
 RSpec.describe PoliciesFinderPublisher do
+  include GdsApi::TestHelpers::ContentRegister
+
+  before do
+    stub_content_register_entries("organisation", [org_1])
+  end
+
+  let(:org_1) do
+    {
+      "content_id" => SecureRandom.uuid,
+      "format" => "organisation",
+      "title" => "Organisation 1",
+      "base_path" => "/government/organisations/organisation-1",
+    }
+  end
 
   let(:publisher) { described_class.new }
 
@@ -8,5 +23,12 @@ RSpec.describe PoliciesFinderPublisher do
     it "validates against govuk-content-schema" do
       expect(publisher.exportable_attributes.as_json).to be_valid_against_schema('finder')
     end
+
+    it "contains the organisations tagged to policies" do
+      policy = FactoryGirl.create(:policy, organisation_content_ids: [org_1["content_id"]])
+      organisation_facet = publisher.exportable_attributes["details"][:facets][1]
+      expect(organisation_facet[:allowed_values]).to match_array([{label: "Organisation 1", value: "organisation-1"}])
+    end
+
   end
 end


### PR DESCRIPTION
As a temporary measure until we can get rummager providing the list of
organisations in finder-frontend hard code the collection of
organisations which have policies in the content-store finder object.

![screen shot 2015-05-14 at 09 36 29](https://cloud.githubusercontent.com/assets/35035/7628587/0f72b3fe-fa1d-11e4-840e-55fdb8f9a32f.png)
