### PR TITLE
Send format_type in email content item

### DIFF
--- a/app/presenters/email_alert_signup_content_item_presenter.rb
+++ b/app/presenters/email_alert_signup_content_item_presenter.rb
@@ -49,6 +49,7 @@ private
       tags: {
         policy: [policy.slug],
       },
+      format_type: "policy",
     }
   end
 

--- a/spec/presenters/email_alert_signup_content_item_presenter_spec.rb
+++ b/spec/presenters/email_alert_signup_content_item_presenter_spec.rb
@@ -31,6 +31,14 @@ RSpec.describe EmailAlertSignupContentItemPresenter do
       expect(presenter.exportable_attributes.as_json['details']["breadcrumbs"]).to eq(breadcrumbs)
     end
 
+    it "includes the format type" do
+      policy = FactoryGirl.create(:policy)
+      presenter = EmailAlertSignupContentItemPresenter.new(policy)
+
+      expect(presenter.exportable_attributes.as_json["details"]["format_type"]).to eq("policy")
+    end
+
+
     it "allows the update type to be overridden" do
       policy = FactoryGirl.create(:policy)
       major_attributes = EmailAlertSignupContentItemPresenter.new(policy).exportable_attributes.as_json


### PR DESCRIPTION
As we want to make sure that duplicate topics don't prevent signups we
need to send the format_type to prepend to the title when sending to
govdelivery. This commit adds it to the content item.

Needs https://github.com/alphagov/govuk-content-schemas/pull/66 to be merged before passing.