### PR TITLE
Send govdelivery_title in email content item

### DIFF
--- a/app/presenters/email_alert_signup_content_item_presenter.rb
+++ b/app/presenters/email_alert_signup_content_item_presenter.rb
@@ -49,6 +49,7 @@ private
       tags: {
         policy: [policy.slug],
       },
+      govdelivery_title: "#{policy.name} policy",
     }
   end
 

--- a/spec/presenters/email_alert_signup_content_item_presenter_spec.rb
+++ b/spec/presenters/email_alert_signup_content_item_presenter_spec.rb
@@ -31,6 +31,13 @@ RSpec.describe EmailAlertSignupContentItemPresenter do
       expect(presenter.exportable_attributes.as_json['details']["breadcrumbs"]).to eq(breadcrumbs)
     end
 
+    it "includes the govdelivery_title" do
+      policy = FactoryGirl.create(:policy, name: "Employment")
+      presenter = EmailAlertSignupContentItemPresenter.new(policy)
+
+      expect(presenter.exportable_attributes.as_json["details"]["govdelivery_title"]).to eq("Employment policy")
+    end
+
     it "allows the update type to be overridden" do
       policy = FactoryGirl.create(:policy)
       major_attributes = EmailAlertSignupContentItemPresenter.new(policy).exportable_attributes.as_json


### PR DESCRIPTION
As we want to make sure that duplicate topics don't prevent signups we
need to send the govdelivery_title which prepends the word policy to the
title to prevent some duplicate topic IDs clashing.

Needs https://github.com/alphagov/govuk-content-schemas/pull/67 to be merged before it passes.