### PR TITLE
Simplify Policies Finder

### DIFF
--- a/lib/policies_finder_publisher.rb
+++ b/lib/policies_finder_publisher.rb
@@ -63,6 +63,7 @@ private
   def details
     {
       document_noun: "policy",
+      default_order: "title",
       filter: {
         document_type: "policy"
       },
@@ -73,14 +74,6 @@ private
 
   def facets
     [
-      {
-        key: "public_timestamp",
-        short_name: "Updated",
-        name: "Published",
-        type: "date",
-        display_as_result_metadata: true,
-        filterable: true
-      },
       {
         key: "organisations",
         short_name: "From",

--- a/spec/lib/policies_finder_publisher_spec.rb
+++ b/spec/lib/policies_finder_publisher_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe PoliciesFinderPublisher do
 
     it "contains the organisations tagged to policies" do
       policy = FactoryGirl.create(:policy, organisation_content_ids: [org_1["content_id"]])
-      organisation_facet = publisher.exportable_attributes["details"][:facets][1]
+      organisation_facet = publisher.exportable_attributes["details"][:facets][0]
       expect(organisation_facet[:allowed_values]).to match_array([{label: "Organisation 1", value: "organisation-1"}])
     end
 


### PR DESCRIPTION
As items in the Policy finder aren't sorted by the date any content was tagged to them it makes sense to remove dates on the Policies finder. Both as result metadata and as a filter. This commit also applies a default_order to the Policy finder to sort by title. [Ticket](https://trello.com/c/gZln2whN/274-simplify-policy-finder-of-finders). 

That ticket also mentions removing atom feeds but I'm going to do that as a separate bit of work.