### PR TITLE
Send parent policy area content ids in programmes

### DIFF
--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -25,6 +25,7 @@ class ContentItemPresenter
         people: people_content_ids,
         related: related,
         email_alert_signup: email_alert_signup_content_id,
+        policy_areas: policy_areas,
       },
     }
   end
@@ -129,6 +130,10 @@ private
 
   def related
     policy.related_policies.map(&:content_id)
+  end
+
+  def policy_areas
+    policy.parent_policies.map(&:content_id)
   end
 
   def facets

--- a/features/step_definitions/policy_steps.rb
+++ b/features/step_definitions/policy_steps.rb
@@ -91,6 +91,7 @@ Then(/^the policy should be linked to the organisation when published to publish
         "people" => [],
         "related" => [],
         "email_alert_signup" => [@policy.email_alert_signup_content_id],
+        "policy_areas" => [],
       },
     }
   )
@@ -109,6 +110,7 @@ Then(/^the policy should be linked to the person when published to publishing AP
         "people" => [person_1["content_id"]],
         "related" => [],
         "email_alert_signup" => [@policy.email_alert_signup_content_id],
+        "policy_areas" => [],
       },
     }
   )

--- a/spec/presenters/content_item_presenter_spec.rb
+++ b/spec/presenters/content_item_presenter_spec.rb
@@ -59,6 +59,14 @@ RSpec.describe ContentItemPresenter do
       expect(attributes["links"]["related"]).to eq([related_policy.content_id])
     end
 
+    it "includes policy areas" do
+      policy_programme = FactoryGirl.create(:policy_programme)
+      policy_area = policy_programme.parent_policies.first
+      attributes = ContentItemPresenter.new(policy_programme).exportable_attributes.as_json
+
+      expect(attributes["links"]["policy_areas"]).to eq([policy_area.content_id])
+    end
+
     it "includes the linked email alert signup" do
       policy = FactoryGirl.create(:policy)
       attributes = ContentItemPresenter.new(policy).exportable_attributes.as_json


### PR DESCRIPTION
In order to infer the parent policy area of a programme we need to send
it as part of the content item. This commit adds it to the links hash of
the content item under `policy_areas`.