### PR TITLE
Output the policy name during mass publish

### DIFF
--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -1,7 +1,10 @@
 namespace :publishing_api do
   desc "Publish all Policies to the Publishing API in reverse alphabetical order"
   task publish_policies: :environment do
-    Policy.all.order("name DESC").each { |policy| Publisher.new(policy).publish! }
+    Policy.all.order("name DESC").each { |policy|
+      puts "Publishing #{policy.name}"
+      Publisher.new(policy).publish!
+    }
   end
 
   desc "Publish the Policies Finder to the Publishing API"


### PR DESCRIPTION
When Publishing all Policies again, it would be good to see which is the
current Policy. This adds it to the rake task.