### PR TITLE
Add rake task to publish signup content items

### DIFF
--- a/db/migrate/20150519132107_publish_email_alert_signup_content_item_for_all_policies.rb
+++ b/db/migrate/20150519132107_publish_email_alert_signup_content_item_for_all_policies.rb
@@ -1,0 +1,8 @@
+class PublishEmailAlertSignupContentItemForAllPolicies < ActiveRecord::Migration
+  def change
+    Policy.all.each do |policy|
+      puts "Publishing email signup content item for #{policy.name}"
+      EmailAlertSignupContentItemPublisher.new(policy).run!
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150501093456) do
+ActiveRecord::Schema.define(version: 20150519132107) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
With the change in https://github.com/alphagov/policy-publisher/pull/69
we need to republish all the signup content items to ensure there are no
duplicate topic names when it comes to create them in Govdelivery.