### PR TITLE
Remove atom route from policies finder

### DIFF
--- a/lib/policies_finder_publisher.rb
+++ b/lib/policies_finder_publisher.rb
@@ -52,10 +52,6 @@ private
       {
         path: "#{base_path}.json",
         type: "exact",
-      },
-      {
-        path: "#{base_path}.atom",
-        type: "exact",
       }
     ]
   end


### PR DESCRIPTION
This route isn't served by the policies finder and shouldn't be sent as
part of the content item.