### PR TITLE
Remove allowed values from Orgs

### DIFF
--- a/lib/policies_finder_publisher.rb
+++ b/lib/policies_finder_publisher.rb
@@ -80,7 +80,6 @@ private
         type: "text",
         display_as_result_metadata: true,
         filterable: true,
-        allowed_values: allowed_organisation_values,
         preposition: "from",
         name: "Organisation",
       },
@@ -89,24 +88,5 @@ private
 
   def publishing_api
     @publishing_api ||= PolicyPublisher.services(:publishing_api)
-  end
-
-  def allowed_organisation_values
-    allowed_orgs = organiastions_used_by_policies.map do |org|
-      { label: org["title"], value: org["base_path"].split('/').last }
-    end
-    allowed_orgs.sort_by {|org| org[:label]}
-  end
-
-  def organiastions_used_by_policies
-    PolicyPublisher.services(:content_register).organisations.select do |org|
-      all_organisation_content_ids.include?(org["content_id"])
-    end
-  end
-
-  def all_organisation_content_ids
-    @all_organisation_content_ids ||= Policy.all.map do |policy|
-      policy.organisation_content_ids
-    end.flatten.uniq
   end
 end

--- a/spec/lib/policies_finder_publisher_spec.rb
+++ b/spec/lib/policies_finder_publisher_spec.rb
@@ -1,34 +1,11 @@
 require "rails_helper"
-require 'gds_api/test_helpers/content_register'
 
 RSpec.describe PoliciesFinderPublisher do
-  include GdsApi::TestHelpers::ContentRegister
-
-  before do
-    stub_content_register_entries("organisation", [org_1])
-  end
-
-  let(:org_1) do
-    {
-      "content_id" => SecureRandom.uuid,
-      "format" => "organisation",
-      "title" => "Organisation 1",
-      "base_path" => "/government/organisations/organisation-1",
-    }
-  end
-
   let(:publisher) { described_class.new }
 
   describe "#exportable_attributes" do
     it "validates against govuk-content-schema" do
       expect(publisher.exportable_attributes.as_json).to be_valid_against_schema('finder')
     end
-
-    it "contains the organisations tagged to policies" do
-      policy = FactoryGirl.create(:policy, organisation_content_ids: [org_1["content_id"]])
-      organisation_facet = publisher.exportable_attributes["details"][:facets][0]
-      expect(organisation_facet[:allowed_values]).to match_array([{label: "Organisation 1", value: "organisation-1"}])
-    end
-
   end
 end


### PR DESCRIPTION
For the Policies Finder, we now pull these dynamically from Rummager, so the Orgs don't need to be included in this facet. [Ticket](https://trello.com/c/dw31ZV0Y/231-add-filter-options-to-finder-of-finders).

Relies on https://github.com/alphagov/finder-frontend/pull/212 being merged first.