### PR TITLE
Add detailed format as a facet

### DIFF
--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -169,11 +169,11 @@ private
         filterable: false
       },
       {
-        key: "display_type",
+        key: "detailed_format",
         short_name: "Type",
         type: "text",
         display_as_result_metadata: true,
-        filterable: false
+        filterable: true
       },
     ]
   end


### PR DESCRIPTION
This commit changes `display_type` to be the new `detailed_format` field
which is returned from Rummager using the `allowed_values`. The need for
this new field comes from the fact that Rummager only has `display_type`
as titlecase strings which means we aren't able to have lowercase URLs.
Using `allowed_values` allows us to have lowercase URLs.

Relies on https://github.com/alphagov/rummager/pull/449 and 
https://github.com/alphagov/whitehall/pull/2218 being merged first.