### PR TITLE
Add people filter to Policy Pages

### DIFF
--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -175,6 +175,13 @@ private
         display_as_result_metadata: true,
         filterable: false
       },
+      {
+        key: "people",
+        name: "People",
+        type: "text",
+        display_as_result_metadata: false,
+        filterable: true
+      },
     ]
   end
 end


### PR DESCRIPTION
This commit adds a filter for People to Policies. [Ticket](https://trello.com/c/IC7LfSed/271-add-people-filter-to-policy-pages). This relies on https://github.com/alphagov/rummager/pull/452 being deployed first and a reindex of Whitehall.

