### PR TITLE
Make Orgs filterable on Policy

### DIFF
--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -166,7 +166,7 @@ private
         short_name: "From",
         type: "text",
         display_as_result_metadata: true,
-        filterable: false
+        filterable: true
       },
       {
         key: "display_type",


### PR DESCRIPTION
This commit updates the Org facet for each Policy to be filterable. This
means that the User can filter tagged documents by the Organisation.