### PR TITLE
Set name fields for filtered facets

### DIFF
--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -163,6 +163,7 @@ private
       },
       {
         key: "organisations",
+        name: "Organisation",
         short_name: "From",
         type: "text",
         display_as_result_metadata: true,
@@ -170,6 +171,7 @@ private
       },
       {
         key: "detailed_format",
+        name: "Type",
         short_name: "Type",
         type: "text",
         display_as_result_metadata: true,


### PR DESCRIPTION
Otherwise the label of the option select is blank, which is bad.

This is a quick fix so we can deploy these facets properly, but
there is an underlying issue, in part because we have quite a few
name-like fields on facets (name, short name, preposition)

Thoughts on longer term fixes:

 1. Making `name` required if `filterable` is set in the content
    schema for this format, and making sure thats enforced, so we
    can catch this early in CI
 2. Simplfying the facet parameters to try and avoid some of the
    naming confusion, eg, requiring `name`, and using it for
    `short_name` or `preposition` if they're not explicitly set.