### PR TITLE
Re-order display of Policy finder facets filters

### DIFF
--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -154,23 +154,6 @@ private
         filterable: false,
       },
       {
-        key: "public_timestamp",
-        short_name: "Updated",
-        name: "Published",
-        type: "date",
-        display_as_result_metadata: true,
-        filterable: true
-      },
-      {
-        key: "organisations",
-        name: "Organisation",
-        short_name: "From",
-        preposition: "from",
-        type: "text",
-        display_as_result_metadata: true,
-        filterable: true
-      },
-      {
         key: "detailed_format",
         name: "Type",
         short_name: "Type",
@@ -185,6 +168,23 @@ private
         preposition: "from",
         type: "text",
         display_as_result_metadata: false,
+        filterable: true
+      },
+      {
+        key: "organisations",
+        name: "Organisation",
+        short_name: "From",
+        preposition: "from",
+        type: "text",
+        display_as_result_metadata: true,
+        filterable: true
+      },
+      {
+        key: "public_timestamp",
+        short_name: "Updated",
+        name: "Published",
+        type: "date",
+        display_as_result_metadata: true,
         filterable: true
       },
     ]


### PR DESCRIPTION
This was on Ben Welby's suggestion, to make them more closely
match the order on other WH finder-esque pages, in particular
putting date filtering at the end, which matches other finders.

They'll appear like this:

![image](https://cloud.githubusercontent.com/assets/63201/8280129/3824caa2-18d2-11e5-8c10-8c390c641905.png)
