### PR TITLE
Remove `detailed_format`, which isn't displaying

### DIFF
--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -154,15 +154,6 @@ private
         filterable: false,
       },
       {
-        key: "detailed_format",
-        name: "Type",
-        short_name: "Type",
-        preposition: "of type",
-        type: "text",
-        display_as_result_metadata: true,
-        filterable: true
-      },
-      {
         key: "people",
         name: "People",
         preposition: "from",


### PR DESCRIPTION
Something is preventing `detailed_format` faceting properly,
most likely in rummager/ES, however i've not been able to track it
down.

At this point it feels safer to remove the facet from master, so
we can deploy the other facet changes, update policies and get
off the hotfix tag for the Rails security upgrade.

Then we can investigate `detailed_format` at our leisure.