### PR TITLE
Bump GDS API adapters to 20.1.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem 'generic_form_builder', '0.13.0'
 gem 'selectize-rails', github: 'manuelvanrijn/selectize-rails', ref: '636897e59fe29'
 gem 'decent_exposure', '2.3.2'
 
-gem 'gds-api-adapters', '18.1.0'
+gem 'gds-api-adapters', '20.1.0'
 
 gem 'govspeak','3.3.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,6 +89,8 @@ GEM
     debugger-linecache (1.2.0)
     decent_exposure (2.3.2)
     diff-lcs (1.2.5)
+    domain_name (0.5.24)
+      unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.5.2)
     factory_girl (4.5.0)
@@ -98,13 +100,13 @@ GEM
       railties (>= 3.0.0)
     faraday (0.9.1)
       multipart-post (>= 1.2, < 3)
-    gds-api-adapters (18.1.0)
+    gds-api-adapters (20.1.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
       plek
       rack-cache
-      rest-client (~> 1.7.3)
+      rest-client (~> 1.8.0)
     gds-sso (10.0.0)
       multi_json (~> 1.0)
       oauth2 (~> 1.0)
@@ -133,6 +135,8 @@ GEM
     hashie (3.4.0)
     hike (1.2.3)
     htmlentities (4.3.3)
+    http-cookie (1.0.2)
+      domain_name (~> 0.5)
     i18n (0.7.0)
     jquery-rails (3.1.3)
       railties (>= 3.0, < 5.0)
@@ -224,7 +228,8 @@ GEM
       thor (>= 0.18.1, < 2.0)
     raindrops (0.13.0)
     rake (10.4.2)
-    rest-client (1.7.3)
+    rest-client (1.8.0)
+      http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 3.0)
       netrc (~> 0.7)
     rspec-core (3.2.3)
@@ -273,6 +278,9 @@ GEM
     uglifier (2.7.0)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.1)
     unicorn (4.8.3)
       kgio (~> 2.6)
       rack
@@ -303,7 +311,7 @@ DEPENDENCIES
   database_cleaner
   decent_exposure (= 2.3.2)
   factory_girl_rails
-  gds-api-adapters (= 18.1.0)
+  gds-api-adapters (= 20.1.0)
   gds-sso (= 10.0.0)
   generic_form_builder (= 0.13.0)
   govspeak (= 3.3.0)


### PR DESCRIPTION
This changes the user agent to include the app
name in API requests.

https://trello.com/c/qkHdtob4/247-bump-gds-api-adapters-everywhere-it-s-used-to-include-user-agent-information