### PR TITLE
Rename policy area and policy programme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Policy publisher
 
-The policy publisher exists to create and manage policy areas and policy programmes
+The policy publisher exists to create and manage policies and policy programmes
 through the Publishing 2.0 pipeline.
 
 ## Nomenclature
 
 - **Policy area**: a broad overview of an area of government activity eg [domestic energy](https://www.gov.uk/government/policies/helping-households-to-cut-their-energy-bills).
 - **Programme**: specific activities the government is taking to support its objectives eg [Green Deal](https://www.gov.uk/government/policies/helping-households-to-cut-their-energy-bills/supporting-pages/green-deal).
-- **Policy**: Either a **policy area** or a **programme**.
+- **Policy**: Either a **policy** or a **programme**.
 
 ## Technical documentation
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,8 @@ through the Publishing 2.0 pipeline.
 
 ## Nomenclature
 
-- **Policy area**: a broad overview of an area of government activity eg [domestic energy](https://www.gov.uk/government/policies/helping-households-to-cut-their-energy-bills).
-- **Programme**: specific activities the government is taking to support its objectives eg [Green Deal](https://www.gov.uk/government/policies/helping-households-to-cut-their-energy-bills/supporting-pages/green-deal).
-- **Policy**: Either a **policy** or a **programme**.
+- **Policy**: a broad overview of an area of government activity eg [domestic energy](https://www.gov.uk/government/policies/helping-households-to-cut-their-energy-bills).
+- **Sub-policy**: specific activities the government is taking to support its objectives eg [Green Deal](https://www.gov.uk/government/policies/helping-households-to-cut-their-energy-bills/supporting-pages/green-deal).
 
 ## Technical documentation
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Policy publisher
 
-The policy publisher exists to create and manage policies and policy programmes
+The policy publisher exists to create and manage policies and sub-policies
 through the Publishing 2.0 pipeline.
 
 ## Nomenclature

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,6 +1,6 @@
 module ApplicationHelper
   def policy_type(policy)
-    policy.programme? ? 'policy programme' : 'policy'
+    policy.sub_policy? ? 'sub-policy' : 'policy'
   end
 
   def nav_link(text, link)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,6 +1,6 @@
 module ApplicationHelper
   def policy_type(policy)
-    policy.programme? ? 'policy programme' : 'policy area'
+    policy.programme? ? 'policy programme' : 'policy'
   end
 
   def nav_link(text, link)

--- a/app/models/policy.rb
+++ b/app/models/policy.rb
@@ -23,12 +23,12 @@ class Policy < ActiveRecord::Base
                             ON policies.id = policy_relations.related_policy_id
                             WHERE policy_relations.related_policy_id IS NULL") }
 
-  # Virtual attribute used to identify a new record as a programme
-  attr_writer :programme
-  def programme
-    @programme || parent_policies.any?
+  # Virtual attribute used to identify a new record as a sub-policy
+  attr_writer :sub_policy
+  def sub_policy
+    @sub_policy || parent_policies.any?
   end
-  alias_method :programme?, :programme
+  alias_method :sub_policy?, :sub_policy
 
   def base_path
     "/government/policies/#{slug}"

--- a/app/views/policies/_form.html.erb
+++ b/app/views/policies/_form.html.erb
@@ -25,7 +25,7 @@
           class: 'select2',
           data: { placeholder: 'Choose working groups…' } } %>
 
-  <% if policy.programme? %>
+  <% if policy.sub_policy? %>
     <%= form.select :parent_policy_ids,
           policies_areas_data_container,
           { label: "Part of" },

--- a/app/views/policies/index.html.erb
+++ b/app/views/policies/index.html.erb
@@ -4,7 +4,7 @@
 
 <p>
   <%= link_to "New policy", new_policy_path, class: 'btn btn-primary' %>
-  <%= link_to "New policy programme", new_policy_path(programme: true), class: 'btn btn-primary' %>
+  <%= link_to "New sub-policy", new_policy_path(sub_policy: true), class: 'btn btn-primary' %>
 </p>
 
 <table class="table table-striped table-bordered" data-module="filterable-table">

--- a/app/views/policies/index.html.erb
+++ b/app/views/policies/index.html.erb
@@ -3,7 +3,7 @@
 <h1>Policies</h1>
 
 <p>
-  <%= link_to "New policy area", new_policy_path, class: 'btn btn-primary' %>
+  <%= link_to "New policy", new_policy_path, class: 'btn btn-primary' %>
   <%= link_to "New policy programme", new_policy_path(programme: true), class: 'btn btn-primary' %>
 </p>
 

--- a/features/policies.feature
+++ b/features/policies.feature
@@ -19,9 +19,9 @@ Scenario: Editing a policy
   And an email alert signup page for a policy called "Climate change" is published to publishing API
   And a policy called "Climate change" is indexed for search
 
-Scenario: Creating a policy programme that is part of another
+Scenario: Creating a sub-policy that is part of another
   Given a published policy exists called "Global warming"
-  When I create a policy programme called "CO2 reduction" that is part of a policy called "Global warming"
+  When I create a sub-policy called "CO2 reduction" that is part of a policy called "Global warming"
   Then there should be a policy called "CO2 reduction" that is part of a policy called "Global warming"
   And a policy called "CO2 reduction" is published to publishing API
   And a policy called "CO2 reduction" is indexed for search

--- a/features/step_definitions/policy_steps.rb
+++ b/features/step_definitions/policy_steps.rb
@@ -24,11 +24,11 @@ When(/^I create a policy called "([^"]+?)"$/) do |policy_name|
   create_policy(name: policy_name)
 end
 
-When(/^I create a policy programme called "(.*?)" that is part of a policy called "(.*?)"$/) do |policy_name, part_of_policy_name|
+When(/^I create a sub-policy called "(.*?)" that is part of a policy called "(.*?)"$/) do |policy_name, part_of_policy_name|
   stub_publishing_api
   stub_rummager
 
-  create_policy_programme(name: policy_name, parent_policies: [part_of_policy_name])
+  create_sub_policy(name: policy_name, parent_policies: [part_of_policy_name])
 end
 
 When(/^I associate the policy with an organisation$/) do

--- a/features/support/policy_helpers.rb
+++ b/features/support/policy_helpers.rb
@@ -27,9 +27,9 @@ module PolicyHelpers
     click_on "Save"
   end
 
-  def create_policy_programme(name:, description: "A policy description", inapplicable_nations: [], alt_policy_urls: {}, parent_policies: [])
+  def create_sub_policy(name:, description: "A policy description", inapplicable_nations: [], alt_policy_urls: {}, parent_policies: [])
     visit policies_path
-    click_on "New policy programme"
+    click_on "New sub-policy"
 
     fill_in "Name", with: name
     fill_in "Description", with: description

--- a/features/support/policy_helpers.rb
+++ b/features/support/policy_helpers.rb
@@ -14,7 +14,7 @@ module PolicyHelpers
 
   def create_policy(name:, description: "A policy description", inapplicable_nations: [], alt_policy_urls: {})
     visit policies_path
-    click_on "New policy area"
+    click_on "New policy"
 
     fill_in "Name", with: name
     fill_in "Description", with: description

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -8,7 +8,7 @@ FactoryGirl.define do
     description "Policy description"
   end
 
-  factory :policy_programme, parent: :policy do
+  factory :sub_policy, parent: :policy do
     parent_policies { [FactoryGirl.create(:policy)] }
   end
 end

--- a/spec/lib/publisher_spec.rb
+++ b/spec/lib/publisher_spec.rb
@@ -34,21 +34,21 @@ RSpec.describe Publisher do
   end
 
 
-  context "when publishing a policy programme" do
-    let!(:policy) { FactoryGirl.create(:policy_programme) }
+  context "when publishing a sub-policy" do
+    let!(:policy) { FactoryGirl.create(:sub_policy) }
 
     before do
       Publisher.new(policy).publish!
     end
 
-    it "publishes the policy programme to the Publishing API" do
+    it "publishes the sub-policy to the Publishing API" do
       assert_publishing_api_put_item(
         policy.base_path,
         ContentItemPresenter.new(policy).exportable_attributes.as_json
       )
     end
 
-    it "adds the policy programme to the rummager search index" do
+    it "adds the sub-policy to the rummager search index" do
       expect(indexer).to have_received(:run!)
     end
 

--- a/spec/models/policy_spec.rb
+++ b/spec/models/policy_spec.rb
@@ -56,16 +56,16 @@ RSpec.describe Policy do
     parent_policy = FactoryGirl.create(:policy)
     policy = FactoryGirl.create(:policy)
 
-    expect(policy.programme?).to be(false)
+    expect(policy.sub_policy?).to be(false)
 
     policy.parent_policies << parent_policy
-    expect(policy.programme?).to be(true)
+    expect(policy.sub_policy?).to be(true)
   end
 
   it "has a setter that can identify a new Policy as a programme" do
-    policy = Policy.new(programme: true)
+    policy = Policy.new(sub_policy: true)
 
-    expect(policy.programme?).to be(true)
+    expect(policy.sub_policy?).to be(true)
   end
 
   it "cannot be associated with itself" do

--- a/spec/presenters/content_item_presenter_spec.rb
+++ b/spec/presenters/content_item_presenter_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe ContentItemPresenter do
       expect(attributes["links"]["related"]).to eq([related_policy.content_id])
     end
 
-    it "includes policy areas" do
+    it "includes policies" do
       policy_programme = FactoryGirl.create(:policy_programme)
       policy_area = policy_programme.parent_policies.first
       attributes = ContentItemPresenter.new(policy_programme).exportable_attributes.as_json

--- a/spec/presenters/content_item_presenter_spec.rb
+++ b/spec/presenters/content_item_presenter_spec.rb
@@ -68,9 +68,9 @@ RSpec.describe ContentItemPresenter do
     end
 
     it "includes policies" do
-      policy_programme = FactoryGirl.create(:policy_programme)
-      policy_area = policy_programme.parent_policies.first
-      attributes = ContentItemPresenter.new(policy_programme).exportable_attributes.as_json
+      sub_policy = FactoryGirl.create(:sub_policy)
+      policy_area = sub_policy.parent_policies.first
+      attributes = ContentItemPresenter.new(sub_policy).exportable_attributes.as_json
 
       expect(attributes["links"]["policy_areas"]).to eq([policy_area.content_id])
     end


### PR DESCRIPTION
The term "policy area" isn't used anywhere else in the interface for policy publisher, and we want to use it in whitehall publisher instead of the word "topic".  The term "policy programme" is also not used anywhere else, and we'd like to rename this.

Therefore, we want to:

 - rename "policy area" in policy-publisher with just "policy"
 - rename "policy programme" in policy-publisher with "sub-policy"

Ticket:https://trello.com/c/K1uPANCo/228-rename-policy-area-in-policy-publisher