### PR TITLE
Add detailed format facet

### DIFF
--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -171,6 +171,15 @@ private
         filterable: true
       },
       {
+        key: "detailed_format",
+        name: "Format",
+        preposition: "of type",
+        type: "text",
+        display_as_result_metadata: true,
+        filterable: true,
+        allowed_values: detailed_format_allowed_values,
+      },
+      {
         key: "public_timestamp",
         short_name: "Updated",
         name: "Published",
@@ -178,6 +187,175 @@ private
         display_as_result_metadata: true,
         filterable: true
       },
+    ]
+  end
+
+  def detailed_format_allowed_values
+    [
+      {
+        label: "Announcement",
+        value: "announcement",
+      },
+      {
+        label: "Case study",
+        value: "case-study",
+      },
+      {
+        label: "Closed consultation",
+        value: "closed-consultation",
+      },
+      {
+        label: "Collection",
+        value: "collection",
+      },
+      {
+        label: "Consultation",
+        value: "consultation",
+      },
+      {
+        label: "Consultation outcome",
+        value: "consultation-outcome",
+      },
+      {
+        label: "Corporate information",
+        value: "corporate-information",
+      },
+      {
+        label: "Corporate report",
+        value: "corporate-report",
+      },
+      {
+        label: "Correspondence",
+        value: "correspondence",
+      },
+      {
+        label: "Decision",
+        value: "decision",
+      },
+      {
+        label: "Detailed guide",
+        value: "detailed-guide",
+      },
+      {
+        label: "Fatality notice",
+        value: "fatality-notice",
+      },
+      {
+        label: "FOI release",
+        value: "foi-release",
+      },
+      {
+        label: "Form",
+        value: "form",
+      },
+      {
+        label: "Government response",
+        value: "government-response",
+      },
+      {
+        label: "Guidance",
+        value: "guidance",
+      },
+      {
+        label: "Impact assessment",
+        value: "impact-assessment",
+      },
+      {
+        label: "Imported - awaiting type",
+        value: "imported-awaiting-type",
+      },
+      {
+        label: "Independent report",
+        value: "independent-report",
+      },
+      {
+        label: "International treaty",
+        value: "international-treaty",
+      },
+      {
+        label: "Map",
+        value: "map",
+      },
+      {
+        label: "News story",
+        value: "news-story",
+      },
+      {
+        label: "Notice",
+        value: "notice",
+      },
+      {
+        label: "Open consultation",
+        value: "open-consultation",
+      },
+      {
+        label: "Policy",
+        value: "policy",
+      },
+      {
+        label: "Policy paper",
+        value: "policy-paper",
+      },
+      {
+        label: "Press release",
+        value: "press-release",
+      },
+      {
+        label: "Promotional material",
+        value: "promotional-material",
+      },
+      {
+        label: "Publication",
+        value: "publication",
+      },
+      {
+        label: "Regulation",
+        value: "regulation",
+      },
+      {
+        label: "Research and analysis",
+        value: "research-and-analysis",
+      },
+      {
+        label: "Speech",
+        value: "speech",
+      },
+      {
+        label: "Statement to Parliament",
+        value: "statement-to-parliament",
+      },
+      {
+        label: "Statistical data set",
+        value: "statistical-data-set",
+      },
+      {
+        label: "Statistics",
+        value: "statistics",
+      },
+      {
+        label: "Statistics - national statistics",
+        value: "statistics-national-statistics",
+      },
+      {
+        label: "Statutory guidance",
+        value: "statutory-guidance",
+      },
+      {
+        label: "Supporting page",
+        value: "supporting-page",
+      },
+      {
+        label: "Transparency data",
+        value: "transparency-data",
+      },
+      {
+        label: "World location news article",
+        value: "world-location-news-article",
+      },
+      {
+        label: "Worldwide priority",
+        value: "worldwide-priority",
+      }
     ]
   end
 end


### PR DESCRIPTION
This commit adds the detailed format facet with the list of allowed
values to the Content Item. Initially we wanted to only store these
allowed values in Rummager but that would require Rummager to expand
facets for things other than Objects. It was then decided that storing
these options in the Content Item is a decent solution until this
happens from Rummager.