### PR TITLE
Update detailed_format_allowed_values.rb

### DIFF
--- a/config/initializers/detailed_format_allowed_values.rb
+++ b/config/initializers/detailed_format_allowed_values.rb
@@ -1,9 +1,5 @@
 DETAILED_FORMAT_ALLOWED_VALUES = [
   {
-    label: "Announcement",
-    value: "announcement",
-  },
-  {
     label: "Case study",
     value: "case-study",
   },
@@ -12,7 +8,7 @@ DETAILED_FORMAT_ALLOWED_VALUES = [
     value: "closed-consultation",
   },
   {
-    label: "Collection",
+    label: "Document collection",
     value: "collection",
   },
   {


### PR DESCRIPTION
Remove announcements as prominent label would confuse users as it contains only content from before April 2013. Rename 'collections' 'document collections'