### PR TITLE
Show Alpha on /policies/all

### DIFF
--- a/lib/policy_firehose_finder_publisher.rb
+++ b/lib/policy_firehose_finder_publisher.rb
@@ -19,6 +19,7 @@ class PolicyFirehoseFinderPublisher
       format: "finder",
       content_id: "ccb6c301-2c64-4a59-88c9-0528d0ffd088",
       title: "All policy content",
+      phase: "alpha",
       description: "",
       public_updated_at: public_updated_at,
       locale: "en",


### PR DESCRIPTION
This adds the Alpha flag to the Policy Firehose. Relies on
https://github.com/alphagov/govuk-content-schemas/pull/105 being merged
before tests will pass.