### PR TITLE
Send `public_timestamp` to rummager

### DIFF
--- a/features/support/rummager_helpers.rb
+++ b/features/support/rummager_helpers.rb
@@ -17,7 +17,7 @@ module RummagerHelpers
       link: policy.base_path,
       indexable_content: "",
       organisations: [],
-      last_update: policy.updated_at,
+      public_timestamp: policy.updated_at,
       _type: "policy",
       _id: policy.base_path,
     }.as_json

--- a/lib/policy_actions/search_indexer.rb
+++ b/lib/policy_actions/search_indexer.rb
@@ -20,7 +20,7 @@ class SearchIndexer
       organisations: get_slugs(policy.organisations),
       people: get_slugs(policy.people),
       policy_groups: get_slugs(policy.working_groups),
-      last_update: policy.updated_at,
+      public_timestamp: policy.updated_at,
     }
   end
 

--- a/spec/lib/policy_actions/search_indexer_spec.rb
+++ b/spec/lib/policy_actions/search_indexer_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe SearchIndexer do
       organisations: ["organisation-1", "organisation-2"],
       people: ["person-1", "person-2"],
       policy_groups: ["working-group-1", "working-group-2"],
-      last_update: policy.updated_at,
+      public_timestamp: policy.updated_at,
       _type: "policy",
       _id: policy.base_path,
     }.as_json


### PR DESCRIPTION
`last_update`  and `public_timestamp` mean the same thing in rummager.

Current behaviour of rummager is that if `public_timestamp` is empty, `last_update` [gets copied into `public_timestamp`](https://github.com/alphagov/rummager/blob/d3637f348612b76ee4de8d2c01048af39ea2a568/lib/indexer/document_preparer.rb#L46).

This commit changes what is sent to rummager so that we populate `public_timestamp` directly and can remove the special field and special code from rummager.

Trello: https://trello.com/c/yY2jFlXl

Previous PRs: https://github.com/alphagov/hmrc-manuals-api/pull/106 & https://github.com/alphagov/specialist-publisher/pull/545 & https://github.com/alphagov/contacts-admin/pull/208
