### PR TITLE
Capitalize the entire app name (Policy *P*ublisher)

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
-<% content_for :app_title, 'GOV.UK Policy publisher' %>
-<% content_for :page_title, ' | GOV.UK Policy publisher' %>
+<% content_for :app_title, 'GOV.UK Policy Publisher' %>
+<% content_for :page_title, ' | GOV.UK Policy Publisher' %>
 <% content_for :favicon do %>
   <% environment_style = GovukAdminTemplate.environment_style %>
   <%= favicon_link_tag environment_style ?


### PR DESCRIPTION
- This irked me the first time I saw Policy Publisher just now, so I'm
  making the capitalization consistent with our other Publishers, for
  example Specialist Publisher.

Before:

![screen shot 2015-09-30 at 15 59 03](https://cloud.githubusercontent.com/assets/355033/10196921/239423bc-678d-11e5-8600-6f6d55820edd.png)

After:

![screen shot 2015-09-30 at 16 05 23](https://cloud.githubusercontent.com/assets/355033/10196908/1870cce2-678d-11e5-8281-a63ee7c48c79.png)
