### PR TITLE
Use 'display_type' Rummager field in results list

### DIFF
--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -159,9 +159,14 @@ private
         name: "Document type",
         preposition: "of type",
         type: "text",
-        display_as_result_metadata: true,
+        display_as_result_metadata: false,
         filterable: true,
         allowed_values: detailed_format_allowed_values,
+      },
+      {
+        key: "display_type",
+        display_as_result_metadata: true,
+        filterable: false,
       },
       {
         key: "organisations",

--- a/lib/policy_firehose_finder_publisher.rb
+++ b/lib/policy_firehose_finder_publisher.rb
@@ -92,9 +92,14 @@ private
         name: "Document type",
         preposition: "of type",
         type: "text",
-        display_as_result_metadata: true,
+        display_as_result_metadata: false,
         filterable: true,
         allowed_values: detailed_format_allowed_values,
+      },
+      {
+        key: "display_type",
+        display_as_result_metadata: true,
+        filterable: false,
       },
       {
         key: "organisations",


### PR DESCRIPTION
In the Rummager results, `detailed_format.value` and
`display_type` contain the same information. Using
`display_type` for the label in the search results
will allow getting rid of the `detailed_format.value`
from Rummager.

/cc @tijmenb @tommyp @rboulton 