### PR TITLE
Fix N+1 query

### DIFF
--- a/app/controllers/policies_controller.rb
+++ b/app/controllers/policies_controller.rb
@@ -1,7 +1,7 @@
 class PoliciesController < ApplicationController
   before_filter :clean_blank_parameters, only: [:create, :update]
   expose(:policy, attributes: :policy_params)
-  expose(:policies) { Policy.order(:name) }
+  expose(:policies) { Policy.includes(:parent_policies).order(:name) }
 
   def index; end
 


### PR DESCRIPTION
Currently the app is making a SQL query for the parent policies for each policy, causing many unnecessary queries.

Before

`ActiveRecord: 89.2ms`

After

`ActiveRecord: 6.6ms`