### PR TITLE
Reinstate the format label for content item results

### DIFF
--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -165,6 +165,7 @@ private
       },
       {
         key: "display_type",
+        type: "text",
         display_as_result_metadata: true,
         filterable: false,
       },

--- a/lib/policy_firehose_finder_publisher.rb
+++ b/lib/policy_firehose_finder_publisher.rb
@@ -98,6 +98,7 @@ private
       },
       {
         key: "display_type",
+        type: "text",
         display_as_result_metadata: true,
         filterable: false,
       },


### PR DESCRIPTION
This label was accidentally removed by PR #106.

I've tested this on preview by pushing this branch and republishing a policy.

/cc @tommyp 