### PR TITLE
Update statistics format labels for clarity

### DIFF
--- a/config/initializers/detailed_format_allowed_values.rb
+++ b/config/initializers/detailed_format_allowed_values.rb
@@ -68,12 +68,20 @@ DETAILED_FORMAT_ALLOWED_VALUES = [
     value: "map",
   },
   {
+    label: "National statistics",
+    value: "statistics-national-statistics",
+  },
+  {
     label: "News story",
     value: "news-story",
   },
   {
     label: "Notice",
     value: "notice",
+  },
+  {
+    label: "Official statistics",
+    value: "statistics",
   },
   {
     label: "Open consultation",
@@ -106,14 +114,6 @@ DETAILED_FORMAT_ALLOWED_VALUES = [
   {
     label: "Statement to Parliament",
     value: "statement-to-parliament",
-  },
-  {
-    label: "Statistics",
-    value: "statistics",
-  },
-  {
-    label: "Statistics - national statistics",
-    value: "statistics-national-statistics",
   },
   {
     label: "Statutory guidance",


### PR DESCRIPTION
In order to reduce confusion for both end-users and departmental users,
the Statistics format is being renamed to Official Statistics, and
"Statistics - national statistics" is being renamed to National
Statistics.

[The story](https://trello.com/c/TxBvx7tD/27-make-it-clearer-that-statistics-are-official-or-national-medium)

This commit changes the labels in the policy facets. The "detailed_format"
values will stay the same because those keys are much harder to change
(than the label) due to other things relying on the specific values
(eg the email alert feeds).

Related Whitehall PR: https://github.com/alphagov/whitehall/pull/2358

/cc @jamiecobbett @tommyp 

**Don't merge until this change has been communicated to the relevant organisations**