### PR TITLE
Capitalising Official and National [S]tatistics

### DIFF
--- a/config/initializers/detailed_format_allowed_values.rb
+++ b/config/initializers/detailed_format_allowed_values.rb
@@ -68,7 +68,7 @@ DETAILED_FORMAT_ALLOWED_VALUES = [
     value: "map",
   },
   {
-    label: "National statistics",
+    label: "National Statistics",
     value: "statistics-national-statistics",
   },
   {
@@ -80,7 +80,7 @@ DETAILED_FORMAT_ALLOWED_VALUES = [
     value: "notice",
   },
   {
-    label: "Official statistics",
+    label: "Official Statistics",
     value: "statistics",
   },
   {


### PR DESCRIPTION
Changes to bring label in line with the style guide, following feedback from the Content team.

https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#statistics

/cc @boffbowsh 