### PR TITLE
Add parent link to email alert signup presenter

### DIFF
--- a/app/presenters/email_alert_signup_content_item_presenter.rb
+++ b/app/presenters/email_alert_signup_content_item_presenter.rb
@@ -18,7 +18,7 @@ class EmailAlertSignupContentItemPresenter
       rendering_app: "email-alert-frontend",
       routes: routes,
       details: details,
-      links: {},
+      links: { parent: [policy.content_id] },
     }
   end
 


### PR DESCRIPTION
Why?:

We want to change email alerting behaviour to use content IDs rather
than slugs. This change will store a reference to the parent policy on
the email alert item stored in the content store. This, in turn, makes
it easier for the email-alert-frontend to handle subscriptions via
email-alert-api by sending the appropriate policy content ID.

How?:

- Update EmailAlertSignupContentItemPresenter#exportable_attributes