### PR TITLE
Include email_alert_type value in details hash for email alert signup

### DIFF
--- a/app/presenters/email_alert_signup_content_item_presenter.rb
+++ b/app/presenters/email_alert_signup_content_item_presenter.rb
@@ -44,6 +44,7 @@ private
 
   def details
     {
+      email_alert_type: "policies",
       breadcrumbs: breadcrumbs,
       summary: summary,
       tags: {


### PR DESCRIPTION
Including this will help email-alert-frontend construct the correct payload
to send to the email-alert-api for subscriptions.