### PR TITLE
Update email alert presenter tags

### DIFF
--- a/app/presenters/email_alert_signup_content_item_presenter.rb
+++ b/app/presenters/email_alert_signup_content_item_presenter.rb
@@ -48,7 +48,7 @@ private
       breadcrumbs: breadcrumbs,
       summary: summary,
       tags: {
-        policy: [policy.slug],
+        policies: [policy.slug],
       },
       govdelivery_title: "#{policy.name} policy",
     }

--- a/spec/presenters/email_alert_signup_content_item_presenter_spec.rb
+++ b/spec/presenters/email_alert_signup_content_item_presenter_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe EmailAlertSignupContentItemPresenter do
       policy = FactoryGirl.create(:policy)
       presenter = EmailAlertSignupContentItemPresenter.new(policy)
       tags = {
-        "policy" => [policy.slug]
+        "policies" => [policy.slug]
       }
 
       expect(presenter.exportable_attributes.as_json['details']["tags"]).to eq(tags)


### PR DESCRIPTION
Change the tags to be keyed on 'policies' rather than 'policy'. This brings
email alerts in line with the rest of gov.uk in the naming of this type of
field and ensures that subscriptions are created correctly by the email-
alerts-frontend.