### PR TITLE
Update email alert tags naming convention

### DIFF
--- a/app/presenters/email_alert_signup_content_item_presenter.rb
+++ b/app/presenters/email_alert_signup_content_item_presenter.rb
@@ -47,8 +47,8 @@ private
       email_alert_type: "policies",
       breadcrumbs: breadcrumbs,
       summary: summary,
-      tags: {
-        policy: [policy.slug],
+      signup_tags: {
+        policies: [policy.slug],
       },
       govdelivery_title: "#{policy.name} policy",
     }

--- a/spec/presenters/email_alert_signup_content_item_presenter_spec.rb
+++ b/spec/presenters/email_alert_signup_content_item_presenter_spec.rb
@@ -11,11 +11,11 @@ RSpec.describe EmailAlertSignupContentItemPresenter do
     it "includes appropriate tags to get the subscriptions URL" do
       policy = FactoryGirl.create(:policy)
       presenter = EmailAlertSignupContentItemPresenter.new(policy)
-      tags = {
-        "policy" => [policy.slug]
+      signup_tags = {
+        "policies" => [policy.slug]
       }
 
-      expect(presenter.exportable_attributes.as_json['details']["tags"]).to eq(tags)
+      expect(presenter.exportable_attributes.as_json['details']["signup_tags"]).to eq(signup_tags)
     end
 
     it "includes breadcrumbs with the relevant policy" do


### PR DESCRIPTION
email_alert_signup content items carry a reference to the piece of
content they handle subscriptions for. Currently, this reference is
namespaced "details > tags". This is problematic when handling policy
alerts. Any published changes to the email signup page results in the
email-alert-service matching on these tags and sending an alert out to
subscribers (via the email-alert-api). This is not the intended behaviour.

Renaming this field to 'signup_tags' makes its purpose explicit and avoids
this unintentional behaviour.