### PR TITLE
Bump `gds-sso` dependency to latest

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'uglifier', '>= 1.3.0'
 gem 'unicorn'
 gem 'quiet_assets', '1.1.0'
 
-gem 'gds-sso', '10.0.0'
+gem 'gds-sso', '~> 11.2'
 gem 'plek', '1.10.0'
 gem 'airbrake', '4.1.0'
 gem 'govuk_admin_template', '~> 3.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,11 +96,11 @@ GEM
       plek
       rack-cache
       rest-client (~> 1.8.0)
-    gds-sso (10.0.0)
+    gds-sso (11.2.1)
       multi_json (~> 1.0)
       oauth2 (~> 1.0)
       omniauth (~> 1.2)
-      omniauth-gds (~> 3.1)
+      omniauth-gds (~> 3.2)
       rack-accept (~> 0.4.4)
       rails (>= 3.0.0)
       warden (~> 1.2)
@@ -300,7 +300,7 @@ DEPENDENCIES
   decent_exposure (= 2.3.2)
   factory_girl_rails
   gds-api-adapters (~> 26.6)
-  gds-sso (= 10.0.0)
+  gds-sso (~> 11.2)
   generic_form_builder (= 0.13.0)
   govspeak (= 3.3.0)
   govuk-content-schema-test-helpers (~> 1.4)

--- a/db/migrate/20160104161439_add_organisation_content_id_to_users.rb
+++ b/db/migrate/20160104161439_add_organisation_content_id_to_users.rb
@@ -1,0 +1,5 @@
+class AddOrganisationContentIdToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :organisation_content_id, :string, null: false, default: ''
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150520142917) do
+ActiveRecord::Schema.define(version: 20160104161439) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -56,8 +56,9 @@ ActiveRecord::Schema.define(version: 20150520142917) do
     t.string  "uid"
     t.string  "organisation_slug"
     t.string  "permissions"
-    t.boolean "remotely_signed_out", default: false
-    t.boolean "disabled",            default: false
+    t.boolean "remotely_signed_out",     default: false
+    t.boolean "disabled",                default: false
+    t.string  "organisation_content_id", default: "",    null: false
   end
 
 end


### PR DESCRIPTION
Bumps `gds-sso` to take advantage of the latest additions and more
robust linting for `User` and `GDS::SSO::User` compatibility.

Added the `User#organisation_content_id` attribute which is now required
for new users created via `gds-sso`. Existing users are unaffected.