### PR TITLE
[WIP] Use publishing-api v2 and remove local storage of link information 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,6 @@ gem 'airbrake', '4.1.0'
 gem 'govuk_admin_template', '~> 3.5'
 gem 'generic_form_builder', '0.13.0'
 gem 'selectize-rails', '~> 0.12.1'
-gem 'decent_exposure', '2.3.2'
 
 gem 'gds-api-adapters', '~> 26.6'
 

--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ gem 'gds-api-adapters', '~> 26.6'
 gem 'govspeak','3.3.0'
 
 group :development, :test do
-  gem 'byebug'
+  gem 'pry-byebug'
   gem 'web-console', '~> 2.0'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,6 +59,7 @@ GEM
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
     cliver (0.3.2)
+    coderay (1.1.0)
     concurrent-ruby (1.0.0)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
@@ -146,6 +147,7 @@ GEM
       PriorityQueue (~> 0.1.2)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
+    method_source (0.8.2)
     mime-types (2.99)
     mini_portile2 (2.0.0)
     minitest (5.8.3)
@@ -179,6 +181,13 @@ GEM
       cliver (~> 0.3.1)
       multi_json (~> 1.0)
       websocket-driver (>= 0.2.0)
+    pry (0.10.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    pry-byebug (3.3.0)
+      byebug (~> 8.0)
+      pry (~> 0.10)
     quiet_assets (1.1.0)
       railties (>= 3.1, < 5.0)
     rack (1.6.4)
@@ -246,6 +255,7 @@ GEM
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
     selectize-rails (0.12.1)
+    slop (3.6.0)
     sprockets (3.5.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -293,7 +303,6 @@ PLATFORMS
 
 DEPENDENCIES
   airbrake (= 4.1.0)
-  byebug
   cucumber-rails
   database_cleaner
   factory_girl_rails
@@ -308,6 +317,7 @@ DEPENDENCIES
   pg
   plek (= 1.10.0)
   poltergeist (= 1.5.0)
+  pry-byebug
   quiet_assets (= 1.1.0)
   rails (= 4.2.5)
   rspec-rails (~> 3.2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,7 +76,6 @@ GEM
       rails (>= 3, < 5)
     database_cleaner (1.5.1)
     debug_inspector (0.0.2)
-    decent_exposure (2.3.2)
     diff-lcs (1.2.5)
     domain_name (0.5.25)
       unf (>= 0.0.5, < 1.0.0)
@@ -297,7 +296,6 @@ DEPENDENCIES
   byebug
   cucumber-rails
   database_cleaner
-  decent_exposure (= 2.3.2)
   factory_girl_rails
   gds-api-adapters (~> 26.6)
   gds-sso (~> 11.2)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,8 +5,4 @@ class ApplicationController < ActionController::Base
 
   include GDS::SSO::ControllerMethods
   before_filter :require_signin_permission!
-
-  decent_configuration do
-    strategy DecentExposure::StrongParametersStrategy
-  end
 end

--- a/app/controllers/policies_controller.rb
+++ b/app/controllers/policies_controller.rb
@@ -1,15 +1,17 @@
 class PoliciesController < ApplicationController
   before_filter :clean_blank_parameters, only: [:create, :update]
-  expose(:policy, attributes: :policy_params)
-  expose(:policies) { Policy.includes(:parent_policies).order(:name) }
 
-  def index; end
+  def index
+    @policies = Policy.includes(:parent_policies).order(:name)
+  end
 
   def new
-    policy.sub_policy = true if params[:sub_policy]
+    @policy = Policy.new
+    @policy.sub_policy = true if params[:sub_policy]
   end
 
   def create
+    policy = Policy.new(policy_params)
     if policy.save
       Publisher.new(policy).publish!
       flash[:success] = "Successfully created a policy"
@@ -18,14 +20,18 @@ class PoliciesController < ApplicationController
     else
       flash[:danger] = "Could not create the policy : #{policy.errors.full_messages.to_sentence.downcase}"
 
+      @policy = policy
       render :new
     end
   end
 
-  def edit; end
+  def edit
+    @policy = Policy.find(params[:id])
+  end
 
   def update
-    if policy.save
+    policy = Policy.find(params[:id])
+    if policy.update_attributes(policy_params)
       Publisher.new(policy).publish!
       flash[:success] = "Successfully updated the policy"
 
@@ -33,6 +39,7 @@ class PoliciesController < ApplicationController
     else
       flash[:danger] = "Could not update the policy: #{policy.errors.full_messages.to_sentence.downcase}"
 
+      @policy = policy
       render :new
     end
   end

--- a/app/controllers/policies_controller.rb
+++ b/app/controllers/policies_controller.rb
@@ -11,7 +11,7 @@ class PoliciesController < ApplicationController
   end
 
   def create
-    policy_form = PolicyForm.from_form(policy_params)
+    policy_form = PolicyForm.new(policy_params)
 
     if policy_form.save
       flash[:success] = "Successfully created a policy"

--- a/app/controllers/policies_controller.rb
+++ b/app/controllers/policies_controller.rb
@@ -6,8 +6,8 @@ class PoliciesController < ApplicationController
   end
 
   def new
-    @policy = PolicyForm.new_with_defaults
-    @policy.sub_policy = true if params[:sub_policy]
+    @policy_form = PolicyForm.new
+    @policy_form.sub_policy = true if params[:sub_policy]
   end
 
   def create
@@ -18,13 +18,13 @@ class PoliciesController < ApplicationController
       redirect_to policies_path
     else
       flash[:danger] = "Could not create the policy : #{policy_form.error_message}"
-      @policy = policy_form
+      @policy_form = policy_form
       render :new
     end
   end
 
   def edit
-    @policy = PolicyForm.from_existing(policy)
+    @policy_form = PolicyForm.from_existing(policy)
   end
 
   def update
@@ -36,7 +36,7 @@ class PoliciesController < ApplicationController
     else
       flash[:danger] = "Could not update the policy: #{policy.errors.full_messages.to_sentence.downcase}"
 
-      @policy = policy_form
+      @policy_form = policy_form
       render :new
     end
   end
@@ -60,7 +60,8 @@ private
   # being included in the resulting parameter array. We clean this out to prevent
   # blank strings being stored.
   def clean_blank_parameters
-    params[:policy][:organisation_content_ids].reject! {|id| id.blank? }
+    params[:policy][:lead_organisation_content_ids].reject! {|id| id.blank? }
+    params[:policy][:supporting_organisation_content_ids].reject! {|id| id.blank? }
     params[:policy][:people_content_ids].reject! {|id| id.blank? }
     params[:policy][:working_group_content_ids].reject! {|id| id.blank? }
   end

--- a/app/controllers/policies_controller.rb
+++ b/app/controllers/policies_controller.rb
@@ -45,6 +45,8 @@ private
 
   def policy
     @policy ||= Policy.find(params[:id])
+    @policy.fetch_links!
+    @policy
   end
 
   def policy_params

--- a/app/controllers/policies_controller.rb
+++ b/app/controllers/policies_controller.rb
@@ -6,64 +6,51 @@ class PoliciesController < ApplicationController
   end
 
   def new
-    @policy = Policy.new
+    @policy = PolicyForm.new_with_defaults
     @policy.sub_policy = true if params[:sub_policy]
   end
 
   def create
-    policy = Policy.new(policy_params)
-    if policy.save
-      Publisher.new(policy).publish!
-      flash[:success] = "Successfully created a policy"
+    policy_form = PolicyForm.from_form(policy_params)
 
+    if policy_form.save
+      flash[:success] = "Successfully created a policy"
       redirect_to policies_path
     else
-      flash[:danger] = "Could not create the policy : #{policy.errors.full_messages.to_sentence.downcase}"
-
-      @policy = policy
+      flash[:danger] = "Could not create the policy : #{policy_form.error_message}"
+      @policy = policy_form
       render :new
     end
   end
 
   def edit
-    @policy = Policy.find(params[:id])
+    @policy = PolicyForm.from_existing(policy)
   end
 
   def update
-    policy = Policy.find(params[:id])
-    if policy.update_attributes(policy_params)
-      Publisher.new(policy).publish!
+    policy_form = PolicyForm.from_existing(policy)
+    if policy_form.update(policy_params)
       flash[:success] = "Successfully updated the policy"
 
       redirect_to policies_path
     else
       flash[:danger] = "Could not update the policy: #{policy.errors.full_messages.to_sentence.downcase}"
 
-      @policy = policy
+      @policy = policy_form
       render :new
     end
   end
 
 private
 
+  def policy
+    @policy ||= Policy.find(params[:id])
+  end
+
   def policy_params
-    params.require(:policy).permit(
-      :name,
-      :description,
-      :england,
-      :england_policy_url,
-      :northern_ireland,
-      :northern_ireland_policy_url,
-      :scotland,
-      :scotland_policy_url,
-      :wales,
-      :wales_policy_url,
-      :sub_policy,
-      organisation_content_ids: [],
-      people_content_ids: [],
-      working_group_content_ids: [],
-      parent_policy_ids: [],
-    )
+    # We don't need to validate here because our forms will only forward
+    # whitelisted attributes.
+    params.require(:policy).permit!
   end
 
   # Rails includes a hidden field for selects on multi-selects so that a value

--- a/app/forms/policy_form.rb
+++ b/app/forms/policy_form.rb
@@ -40,10 +40,6 @@ class PolicyForm
     )
   end
 
-  def self.from_form(policy_params)
-    new(policy_params)
-  end
-
   def self.from_existing(policy)
     form = new(policy.as_json(only: ATTRIBUTES))
     form.policy = policy

--- a/app/forms/policy_form.rb
+++ b/app/forms/policy_form.rb
@@ -18,7 +18,7 @@ class PolicyForm
     parent_policy_ids
   ]
 
-  attr_accessor *ATTRIBUTES
+  attr_accessor(*ATTRIBUTES)
   attr_accessor :policy
 
   include ActiveModel::Model
@@ -45,7 +45,7 @@ class PolicyForm
   end
 
   def self.from_existing(policy)
-    form = new(policy.as_json.slice(*ATTRIBUTES))
+    form = new(policy.as_json(only: ATTRIBUTES))
     form.policy = policy
     form
   end
@@ -56,7 +56,7 @@ class PolicyForm
   end
 
   def save
-    attributes = as_json.slice(*ATTRIBUTES)
+    attributes = as_json(only: ATTRIBUTES)
     policy.update_attributes(attributes) && publish!
   end
 
@@ -78,6 +78,18 @@ class PolicyForm
 
   def sub_policy?
     sub_policy
+  end
+
+  def organisation_content_ids
+    policy.organisation_content_ids
+  end
+
+  def people_content_ids
+    policy.people_content_ids
+  end
+
+  def working_group_content_ids
+    policy.working_group_content_ids
   end
 
 private

--- a/app/forms/policy_form.rb
+++ b/app/forms/policy_form.rb
@@ -1,0 +1,88 @@
+class PolicyForm
+  ATTRIBUTES = %w[
+    id
+    name
+    description
+    sub_policy
+    england
+    england_policy_url
+    northern_ireland
+    northern_ireland_policy_url
+    scotland
+    scotland_policy_url
+    wales
+    wales_policy_url
+    organisation_content_ids
+    people_content_ids
+    working_group_content_ids
+    parent_policy_ids
+  ]
+
+  attr_accessor *ATTRIBUTES
+  attr_accessor :policy
+
+  include ActiveModel::Model
+
+  def self.model_name
+    ActiveModel::Name.new(Policy)
+  end
+
+  def self.new_with_defaults
+    new(
+      england: true,
+      scotland: true,
+      wales: true,
+      northern_ireland: true,
+      organisation_content_ids: [],
+      people_content_ids: [],
+      working_group_content_ids: [],
+      parent_policy_ids: [],
+    )
+  end
+
+  def self.from_form(policy_params)
+    new(policy_params)
+  end
+
+  def self.from_existing(policy)
+    form = new(policy.as_json.slice(*ATTRIBUTES))
+    form.policy = policy
+    form
+  end
+
+  def update(attrs)
+    attrs.each { |k, v| self.send("#{k}=", v) }
+    save
+  end
+
+  def save
+    attributes = as_json.slice(*ATTRIBUTES)
+    policy.update_attributes(attributes) && publish!
+  end
+
+  def error_message
+    policy.errors.full_messages.to_sentence.downcase
+  end
+
+  def policy
+    @policy ||= Policy.new
+  end
+
+  def persisted?
+    policy.id.present?
+  end
+
+  def possible_nations
+    policy.possible_nations
+  end
+
+  def sub_policy?
+    sub_policy
+  end
+
+private
+  def publish!
+    Publisher.new(policy).publish!
+    true
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -19,17 +19,20 @@ module ApplicationHelper
   # Data container used to generate the options for an organisations select field
   def organisations_data_container
     ContentItemFetcher.new.organisations
+      .sort_by { |organisation| organisation['title'] }
       .map { |org| [org['title'], org['content_id']] }
   end
 
   # Data container used to generate the options for a people select field
   def people_data_container
     ContentItemFetcher.new.people
+      .sort_by { |person| person['title'] }
       .map { |person| [person['title'], person['content_id']] }
   end
 
   def working_groups_data_container
     ContentItemFetcher.new.working_groups
+      .sort_by { |working_group| working_group['title'] }
       .map { |wg| [wg['title'], wg['content_id']] }
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -18,18 +18,18 @@ module ApplicationHelper
 
   # Data container used to generate the options for an organisations select field
   def organisations_data_container
-    ContentItemFetcher.organisations
+    ContentItemFetcher.new.organisations
       .map { |org| [org['title'], org['content_id']] }
   end
 
   # Data container used to generate the options for a people select field
   def people_data_container
-    ContentItemFetcher.people
+    ContentItemFetcher.new.people
       .map { |person| [person['title'], person['content_id']] }
   end
 
   def working_groups_data_container
-    ContentItemFetcher.working_groups
+    ContentItemFetcher.new.working_groups
       .map { |wg| [wg['title'], wg['content_id']] }
   end
 

--- a/app/models/policy.rb
+++ b/app/models/policy.rb
@@ -61,16 +61,16 @@ class Policy < ActiveRecord::Base
     possible_nations - applicable_nations
   end
 
-  def organisations
-    organisation_content_ids.map { |content_id| find_organisation(content_id) }.compact
+  def organisations(fetcher = ContentItemFetcher.new)
+    @fetched_organisations ||= organisation_content_ids.map { |content_id| fetcher.find_organisation(content_id) }.compact
   end
 
-  def people
-    people_content_ids.map { |content_id| find_person(content_id) }.compact
+  def people(fetcher = ContentItemFetcher.new)
+    @fetched_people ||= people_content_ids.map { |content_id| fetcher.find_person(content_id) }.compact
   end
 
-  def working_groups
-    working_group_content_ids.map { |content_id| find_working_group(content_id) }.compact
+  def working_groups(fetcher = ContentItemFetcher.new)
+    @fetched_working_groups ||= working_group_content_ids.map { |content_id| fetcher.find_working_group(content_id) }.compact
   end
 
   # Fetch links from the publisher-api
@@ -86,18 +86,6 @@ class Policy < ActiveRecord::Base
 
 
 private
-  def find_person(content_id)
-    ContentItemFetcher.people.find { |person| person["content_id"] == content_id }
-  end
-
-  def find_organisation(content_id)
-    ContentItemFetcher.organisations.find { |organisation| organisation["content_id"] == content_id }
-  end
-
-  def find_working_group(content_id)
-    ContentItemFetcher.working_groups.find { |wg| wg["content_id"] == content_id }
-  end
-
   def applicable_to_at_least_one_nation
     if applicable_nations.empty?
       errors.add(:applicability, "must have at least one nation")

--- a/app/models/policy.rb
+++ b/app/models/policy.rb
@@ -11,7 +11,7 @@ class Policy < ActiveRecord::Base
   has_many :related_policies, class_name: 'Policy', through: :policy_relations, source: :related_policy
 
   has_many :inverse_policy_relations, class_name: 'PolicyRelation', foreign_key: 'related_policy_id'
-  has_many :parent_policies,  through: :inverse_policy_relations, source: :policy
+  has_many :parent_policies, through: :inverse_policy_relations, source: :policy
 
   before_validation on: :create do |object|
     object.slug = object.name.to_s.parameterize
@@ -30,6 +30,16 @@ class Policy < ActiveRecord::Base
   end
   alias_method :sub_policy?, :sub_policy
 
+  attr_accessor :organisation_content_ids
+  attr_accessor :people_content_ids
+  attr_accessor :working_group_content_ids
+
+  after_initialize do
+    self.organisation_content_ids = []
+    self.people_content_ids = []
+    self.working_group_content_ids = []
+  end
+
   def base_path
     "/government/policies/#{slug}"
   end
@@ -44,9 +54,7 @@ class Policy < ActiveRecord::Base
   end
 
   def applicable_nations
-    applicable_nations = possible_nations.select { |n|
-      self.send(n) == true
-    }
+    possible_nations.select { |n| self.send(n) == true }
   end
 
   def inapplicable_nations
@@ -64,6 +72,18 @@ class Policy < ActiveRecord::Base
   def working_groups
     working_group_content_ids.map { |content_id| find_working_group(content_id) }.compact
   end
+
+  # Fetch links from the publisher-api
+  def fetch_links!
+    if content_id.nil?
+      return
+    end
+    links = Services.publishing_api.get_links(content_id)["links"]
+    self.organisation_content_ids = links["organisations"] || []
+    self.people_content_ids = links["people"] || []
+    self.working_group_content_ids = links["working_groups"] || []
+  end
+
 
 private
   def find_person(content_id)

--- a/app/models/policy.rb
+++ b/app/models/policy.rb
@@ -75,9 +75,8 @@ class Policy < ActiveRecord::Base
 
   # Fetch links from the publisher-api
   def fetch_links!
-    if content_id.nil?
-      return
-    end
+    return if content_id.nil?
+
     links = Services.publishing_api.get_links(content_id)["links"]
     self.organisation_content_ids = links["organisations"] || []
     self.people_content_ids = links["people"] || []

--- a/app/presenters/links_presenter.rb
+++ b/app/presenters/links_presenter.rb
@@ -9,6 +9,7 @@ class LinksPresenter
     {
       links: {
         organisations: organisation_content_ids,
+        lead_organisations: lead_organisation_content_ids,
         people: people_content_ids,
         working_groups: working_group_content_ids,
         related: related,
@@ -22,6 +23,10 @@ private
 
   def organisation_content_ids
     policy.organisation_content_ids || []
+  end
+
+  def lead_organisation_content_ids
+    policy.lead_organisation_content_ids || []
   end
 
   def people_content_ids

--- a/app/views/policies/_form.html.erb
+++ b/app/views/policies/_form.html.erb
@@ -1,31 +1,38 @@
-<%= form_for policy do |form| %>
+<%= form_for policy_form do |form| %>
   <%= form.hidden_field :sub_policy %>
 
   <%= form.text_field :name %>
   <%= form.text_area :description %>
 
-  <%= form.select :organisation_content_ids,
-        prioritise_data_container(organisations_data_container, policy.organisation_content_ids),
-        { label: "Organisations" },
+  <%= form.select :lead_organisation_content_ids,
+        prioritise_data_container(organisations_data_container, policy_form.lead_organisation_content_ids),
+        { label: "Lead organisations" },
         { multiple: true,
           class: 'select2',
-          data: { placeholder: 'Choose organisations…' } } %>
+          data: { placeholder: 'Choose lead organisations…' } } %>
+
+  <%= form.select :supporting_organisation_content_ids,
+        prioritise_data_container(organisations_data_container, policy_form.supporting_organisation_content_ids),
+        { label: "Supporting organisations" },
+        { multiple: true,
+          class: 'select2',
+          data: { placeholder: 'Choose supporting organisations…' } } %>
 
   <%= form.select :people_content_ids,
-        prioritise_data_container(people_data_container, policy.people_content_ids),
+        prioritise_data_container(people_data_container, policy_form.people_content_ids),
         { label: "People" },
         { multiple: true,
           class: 'select2',
           data: { placeholder: 'Choose people…' } } %>
 
   <%= form.select :working_group_content_ids,
-        prioritise_data_container(working_groups_data_container, policy.working_group_content_ids),
+        prioritise_data_container(working_groups_data_container, policy_form.working_group_content_ids),
         { label: "Working groups" },
         { multiple: true,
           class: 'select2',
           data: { placeholder: 'Choose working groups…' } } %>
 
-  <% if policy.sub_policy? %>
+  <% if policy_form.sub_policy? %>
     <%= form.select :parent_policy_ids,
           policies_areas_data_container,
           { label: "Part of" },

--- a/app/views/policies/edit.html.erb
+++ b/app/views/policies/edit.html.erb
@@ -1,5 +1,5 @@
-<%= content_for :page_title, "Edit policy #{policy_type(policy)}" %>
+<%= content_for :page_title, "Edit policy #{policy_type(@policy)}" %>
 
-<h1>Edit <%= policy_type(policy) %> </h1>
+<h1>Edit <%= policy_type(@policy) %> </h1>
 
-<%= render "form" %>
+<%= render "form", policy: @policy %>

--- a/app/views/policies/edit.html.erb
+++ b/app/views/policies/edit.html.erb
@@ -1,5 +1,5 @@
-<%= content_for :page_title, "Edit policy #{policy_type(@policy)}" %>
+<%= content_for :page_title, "Edit policy #{policy_type(@policy_form)}" %>
 
-<h1>Edit <%= policy_type(@policy) %> </h1>
+<h1>Edit <%= policy_type(@policy_form) %> </h1>
 
-<%= render "form", policy: @policy %>
+<%= render "form", policy_form: @policy_form %>

--- a/app/views/policies/index.html.erb
+++ b/app/views/policies/index.html.erb
@@ -25,7 +25,7 @@
   </thead>
 
   <tbody>
-    <% policies.each do |policy| %>
+    <% @policies.each do |policy| %>
       <%= content_tag_for(:tr, policy) do %>
         <td><%= link_to policy.name, edit_policy_path(policy) %></td>
         <td><%= policy.updated_at.to_s(:govuk_date) %></td>

--- a/app/views/policies/new.html.erb
+++ b/app/views/policies/new.html.erb
@@ -1,5 +1,5 @@
-<%= content_for :page_title, "New policy #{policy_type(policy)}" %>
+<%= content_for :page_title, "New policy #{policy_type(@policy)}" %>
 
-<h1>New <%= policy_type(policy) %> </h1>
+<h1>New <%= policy_type(@policy) %> </h1>
 
-<%= render "form" %>
+<%= render "form", policy: @policy %>

--- a/app/views/policies/new.html.erb
+++ b/app/views/policies/new.html.erb
@@ -1,5 +1,5 @@
-<%= content_for :page_title, "New policy #{policy_type(@policy)}" %>
+<%= content_for :page_title, "New policy #{policy_type(@policy_form)}" %>
 
-<h1>New <%= policy_type(@policy) %> </h1>
+<h1>New <%= policy_type(@policy_form) %> </h1>
 
-<%= render "form", policy: @policy %>
+<%= render "form", policy_form: @policy_form %>

--- a/db/migrate/20160114121308_remove_link_fields.rb
+++ b/db/migrate/20160114121308_remove_link_fields.rb
@@ -1,0 +1,18 @@
+class RemoveLinkFields < ActiveRecord::Migration
+  def up
+    change_table :policies do |t|
+      t.remove :organisation_content_ids
+      t.remove :people_content_ids
+      t.remove :working_group_content_ids
+    end
+  end
+
+  def down
+    change_table :policies do |t|
+      t.text    :organisation_content_ids, array: true, default: []
+      t.text    :people_content_ids, array: true, default: []
+      t.text    :working_group_content_ids, array: true, default: []
+    end
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160104161439) do
+ActiveRecord::Schema.define(version: 20160114121308) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,8 +21,6 @@ ActiveRecord::Schema.define(version: 20160104161439) do
     t.string   "name"
     t.text     "description"
     t.string   "content_id"
-    t.text     "organisation_content_ids",      default: [],                array: true
-    t.text     "people_content_ids",            default: [],                array: true
     t.boolean  "england",                       default: true
     t.string   "england_policy_url"
     t.boolean  "northern_ireland",              default: true
@@ -34,7 +32,6 @@ ActiveRecord::Schema.define(version: 20160104161439) do
     t.datetime "created_at",                                   null: false
     t.datetime "updated_at",                                   null: false
     t.string   "email_alert_signup_content_id"
-    t.text     "working_group_content_ids",     default: [],                array: true
   end
 
   add_index "policies", ["email_alert_signup_content_id"], name: "index_policies_on_email_alert_signup_content_id", unique: true, using: :btree

--- a/features/policies.feature
+++ b/features/policies.feature
@@ -52,21 +52,6 @@ Scenario: Preserving links while editing a policy
   When I change the title of policy "Global warming" to "Climate change"
   Then the policy links should remain unchanged
 
-# TODO: ordering is not currently preserved by the publishing-api
-#@javascript
-#Scenario: Re-ordering tagged organisations
-#  Given a policy exists called "Global warming"
-#  And the policy is associated with the organisations "Organisation 1" and "Organisation 2"
-#  When I set the tagged organisations to "Organisation 2" and "Organisation 1"
-#  Then the policy organisations should appear in the order "Organisation 2" and "Organisation 1"
-#
-#@javascript
-#Scenario: Re-ordering tagged people
-#  Given a policy exists called "Global warming"
-#  And the policy is associated with the people "A Person" and "Another Person"
-#  When I set the tagged people to "Another Person" and "A Person"
-#  Then the policy people should appear in the order "Another Person" and "A Person"
-
 @javascript
 Scenario: Creating a policy only associated with one nation
   When I visit the main browse page

--- a/features/policies.feature
+++ b/features/policies.feature
@@ -46,19 +46,26 @@ Scenario: Associating a policy with a working group
   When I associate the policy with a working group
   Then the policy should be linked to the working group when published to publishing API
 
-@javascript
-Scenario: Re-ordering tagged organisations
+Scenario: Preserving links while editing a policy
   Given a policy exists called "Global warming"
-  And the policy is associated with the organisations "Organisation 1" and "Organisation 2"
-  When I set the tagged organisations to "Organisation 2" and "Organisation 1"
-  Then the policy organisations should appear in the order "Organisation 2" and "Organisation 1"
+  And it is associated with two organisations, two people and two working groups
+  When I change the title of policy "Global warming" to "Climate change"
+  Then the policy links should remain unchanged
 
-@javascript
-Scenario: Re-ordering tagged people
-  Given a policy exists called "Global warming"
-  And the policy is associated with the people "A Person" and "Another Person"
-  When I set the tagged people to "Another Person" and "A Person"
-  Then the policy people should appear in the order "Another Person" and "A Person"
+# TODO: ordering is not currently preserved by the publishing-api
+#@javascript
+#Scenario: Re-ordering tagged organisations
+#  Given a policy exists called "Global warming"
+#  And the policy is associated with the organisations "Organisation 1" and "Organisation 2"
+#  When I set the tagged organisations to "Organisation 2" and "Organisation 1"
+#  Then the policy organisations should appear in the order "Organisation 2" and "Organisation 1"
+#
+#@javascript
+#Scenario: Re-ordering tagged people
+#  Given a policy exists called "Global warming"
+#  And the policy is associated with the people "A Person" and "Another Person"
+#  When I set the tagged people to "Another Person" and "A Person"
+#  Then the policy people should appear in the order "Another Person" and "A Person"
 
 @javascript
 Scenario: Creating a policy only associated with one nation

--- a/features/step_definitions/policy_steps.rb
+++ b/features/step_definitions/policy_steps.rb
@@ -5,14 +5,6 @@ Given(/^a (?:published )?policy exists called "(.*?)"$/) do |policy_name|
   stub_publishing_api_links(@policy.content_id)
 end
 
-Given(/^the policy is associated with the organisations "(.*?)" and "(.*?)"$/) do |org_name_1, org_name_2|
-  associate_policy_with_organisations(policy: @policy, organisation_names: [org_name_1, org_name_2])
-end
-
-Given(/^the policy is associated with the people "(.*?)" and "(.*?)"$/) do |person_name_1, person_name_2|
-  associate_policy_with_people(policy: @policy, people_names: [person_name_1, person_name_2])
-end
-
 Given(/^it is associated with two organisations, two people and two working groups$/) do
   stub_publishing_api_links(
     @policy.content_id,
@@ -241,20 +233,6 @@ Then(/^the policy links should remain unchanged$/) do
       }
     }
   )
-end
-
-Then(/^the policy organisations should appear in the order "(.*?)" and "(.*?)"$/) do |org_name_1, org_name_2|
-  first_org = ContentItemFetcher.organisations.find { |organisation| organisation["title"] == org_name_1 }
-  second_org = ContentItemFetcher.organisations.find { |organisation| organisation["title"] == org_name_2 }
-
-  expect(@policy.reload.organisations).to eq([first_org, second_org])
-end
-
-Then(/^the policy people should appear in the order "(.*?)" and "(.*?)"$/) do |person_name_1, person_name_2|
-  first_person = ContentItemFetcher.people.find { |person| person["title"] == person_name_1 }
-  second_person = ContentItemFetcher.people.find { |person| person["title"] == person_name_2 }
-
-  expect(@policy.reload.people).to eq([first_person, second_person])
 end
 
 When(/^I create a policy called "([^"]+?)" that only applies to "([^"]+?)"$/) do |policy_name, nation|

--- a/features/step_definitions/policy_steps.rb
+++ b/features/step_definitions/policy_steps.rb
@@ -2,6 +2,7 @@ Given(/^a (?:published )?policy exists called "(.*?)"$/) do |policy_name|
   stub_any_publishing_api_write
   stub_rummager
   @policy = FactoryGirl.create(:policy, name: policy_name)
+  stub_publishing_api_links(@policy.content_id)
 end
 
 Given(/^the policy is associated with the organisations "(.*?)" and "(.*?)"$/) do |org_name_1, org_name_2|
@@ -10,6 +11,20 @@ end
 
 Given(/^the policy is associated with the people "(.*?)" and "(.*?)"$/) do |person_name_1, person_name_2|
   associate_policy_with_people(policy: @policy, people_names: [person_name_1, person_name_2])
+end
+
+Given(/^it is associated with two organisations, two people and two working groups$/) do
+  stub_publishing_api_links(
+    @policy.content_id,
+    organisations: [@organisation_1, @organisation_2].map {|org| org["content_id"]},
+    people: [@person_1, @person_2].map {|person| person["content_id"]},
+    working_groups: [@working_group_1, @working_group_2].map {|working_group| working_group["content_id"]}
+  )
+
+  items = [organisation_1, organisation_2, person_1, person_2, working_group_1, working_group_2]
+  items.each do |item|
+    publishing_api_has_item(item)
+  end
 end
 
 When(/^I change the title of policy "(.*?)" to "(.*?)"$/) do |old_name, new_name|
@@ -39,6 +54,8 @@ When(/^I create a sub-policy called "(.*?)" that is part of a policy called "(.*
   create_sub_policy(name: policy_name, parent_policies: [part_of_policy_name])
 end
 
+# NB: if the publishing-api has not been stubbed in another step,
+# these steps will act like the policy is not linked to anything before we edit it.
 When(/^I associate the policy with an organisation$/) do
   associate_policy_with_organisation(policy: @policy, organisation_name: 'Organisation 1')
 end
@@ -191,6 +208,33 @@ Then(/^the policy should be linked to the working group when published to publis
         "organisations" => [],
         "people" => [],
         "working_groups" => [working_group_1["content_id"]],
+        "related" => [],
+        "email_alert_signup" => [@policy.email_alert_signup_content_id],
+        "policy_areas" => [],
+      }
+    }
+  )
+end
+
+# The links we put to the publisher-api should match the links we got
+Then(/^the policy links should remain unchanged$/) do
+  assert_publishing_api_put_content(
+    @policy.content_id,
+    {
+      "format" => "policy",
+      "rendering_app" => "finder-frontend",
+      "publishing_app" => "policy-publisher",
+      "locale" => "en",
+    }
+  )
+
+  assert_publishing_api_put_links(
+    @policy.content_id,
+    {
+      "links" => {
+        "organisations" => [organisation_1["content_id"], organisation_2["content_id"]],
+        "people" => [person_1["content_id"], person_2["content_id"]],
+        "working_groups" => [working_group_1["content_id"], working_group_2["content_id"]],
         "related" => [],
         "email_alert_signup" => [@policy.email_alert_signup_content_id],
         "policy_areas" => [],

--- a/features/support/policy_helpers.rb
+++ b/features/support/policy_helpers.rb
@@ -76,7 +76,7 @@ module PolicyHelpers
 
   def associate_policy_with_organisation(policy:, organisation_name:)
     visit_policy(policy)
-    select organisation_name, from: "Organisations"
+    select organisation_name, from: "Lead organisations"
     click_on "Save"
   end
 

--- a/lib/content_item_fetcher.rb
+++ b/lib/content_item_fetcher.rb
@@ -2,24 +2,36 @@
 class ContentItemFetcher
   FIELDS = %w(content_id format title base_path)
 
-  def self.organisations
-    Services.publishing_api.get_content_items(
+  def organisations
+    @organisations ||= Services.publishing_api.get_content_items(
       content_format: 'organisation',
       fields: FIELDS
     )
   end
 
-  def self.people
-    Services.publishing_api.get_content_items(
+  def people
+    @people ||= Services.publishing_api.get_content_items(
       content_format: 'person',
       fields: FIELDS
     )
   end
 
-  def self.working_groups
-    Services.publishing_api.get_content_items(
+  def working_groups
+    @working_groups ||= Services.publishing_api.get_content_items(
       content_format: 'working_group',
       fields: FIELDS
     )
+  end
+
+  def find_person(content_id)
+    people.find { |person| person["content_id"] == content_id }
+  end
+
+  def find_organisation(content_id)
+    organisations.find { |organisation| organisation["content_id"] == content_id }
+  end
+
+  def find_working_group(content_id)
+    working_groups.find { |wg| wg["content_id"] == content_id }
   end
 end

--- a/spec/lib/policy_actions/content_item_publisher_spec.rb
+++ b/spec/lib/policy_actions/content_item_publisher_spec.rb
@@ -29,4 +29,18 @@ RSpec.describe ContentItemPublisher do
       )
     end
   end
+
+  describe '#content_payload' do
+    it "publishes lead organisations and organisations in the links hash" do
+      lead       = [SecureRandom.uuid]
+      supporting = [SecureRandom.uuid, SecureRandom.uuid]
+      policy.set_organisation_priority(lead, supporting)
+
+      links_payload = content_item_publisher.links_payload
+
+      expect(links_payload).to_not be_empty
+      expect(links_payload[:links][:organisations]).to eql(lead + supporting)
+      expect(links_payload[:links][:lead_organisations]).to eql(lead)
+    end
+  end
 end

--- a/spec/models/policy_spec.rb
+++ b/spec/models/policy_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe Policy do
     expect { policy.related_policies = [policy] }.to raise_error(ActiveRecord::RecordInvalid)
   end
 
-  it "maintains the ordering of tagged organisations" do
+  it "caches tagged organisations" do
     stub_content_calls_from_publishing_api
 
     policy = FactoryGirl.create(:policy,
@@ -87,10 +87,14 @@ RSpec.describe Policy do
 
     policy.organisation_content_ids = [organisation_2['content_id'], organisation_1['content_id']]
 
-    expect(policy.organisations).to eq([organisation_2, organisation_1])
+    expect(policy.organisations).to eq([organisation_1, organisation_2])
+
+    first_read = policy.organisations.object_id
+    second_read = policy.organisations.object_id
+    expect(first_read).to eq(second_read)
   end
 
-  it "maintains the ordering of tagged people" do
+  it "caches tagged people" do
     stub_content_calls_from_publishing_api
 
     policy = FactoryGirl.create(:policy,
@@ -103,10 +107,14 @@ RSpec.describe Policy do
 
     policy.people_content_ids = [person_2['content_id'], person_1['content_id']]
 
-    expect(policy.people).to eq([person_2, person_1])
+    expect(policy.people).to eq([person_1, person_2])
+
+    first_read = policy.people.object_id
+    second_read = policy.people.object_id
+    expect(first_read).to eq(second_read)
   end
 
-  it "maintains the ordering of tagged groups" do
+  it "caches tagged groups" do
     stub_content_calls_from_publishing_api
 
     policy = FactoryGirl.create(:policy,
@@ -119,7 +127,11 @@ RSpec.describe Policy do
 
     policy.working_group_content_ids = [working_group_2['content_id'], working_group_1['content_id']]
 
-    expect(policy.working_groups).to eq([working_group_2, working_group_1])
+    expect(policy.working_groups).to eq([working_group_1, working_group_2])
+
+    first_read = policy.working_groups.object_id
+    second_read = policy.working_groups.object_id
+    expect(first_read).to eq(second_read)
   end
 
   it "ignores non-existent tagged organisations" do

--- a/spec/models/policy_spec.rb
+++ b/spec/models/policy_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe Policy do
 
     expect(policy.organisations).to eq([organisation_1, organisation_2])
 
-    policy.organisation_content_ids = [organisation_2['content_id'], organisation_1['content_id']]
+    policy.organisation_content_ids = {lead: [organisation_2['content_id'], supporting: organisation_1['content_id']] }
 
     expect(policy.organisations).to eq([organisation_1, organisation_2])
 

--- a/spec/support/publishing_api_content_helpers.rb
+++ b/spec/support/publishing_api_content_helpers.rb
@@ -73,4 +73,19 @@ module PublishingApiContentHelpers
       "base_path" => "/government/groups/another-working_group",
     }
   end
+
+  def stub_publishing_api_links(content_id, organisations: [], people: [], working_groups: [])
+    url = PUBLISHING_API_V2_ENDPOINT + "/links/" + content_id
+    links = {
+      links: {
+        organisations: organisations,
+        people: people,
+        working_groups: working_groups,
+        related: [],
+        email_alert_signup: [
+        ]
+      }
+    }
+    stub_request(:get, url).to_return(status: 200, body: links.to_json, headers: {})
+  end
 end


### PR DESCRIPTION
NB: this ticket was started by @tijmenb on branch refactor-for-tagging-migration. If this PR is too noisy I can recreate it against that base.

## What I've done so far
I've removed organisation/people/working_group content ids from the policy-publisher database, and instead loaded that data from the publishing-api before we render the update form.

I diverged slightly from the approach @tijmenb suggested on the trello ticket, as I kept the link fields as part of the active record model after removing them from the schema. There are several places where the fields are accessed in this way at the moment and I didn't want to change things too much for the first iteration.

I've changed the cucumber tests so that this call is stubbed out to return predefined data and added a new scenario to verify links will be persisted - i.e. intercept the GET and PUT calls to /links and make sure they match up. I'm not too familiar with cucumber or the way we do stubbing so feedback on this would be helpful.

## What I'm working on
Before I can test this manually I need to investigate some performance issues introduced by the switch to the publishing API. There is also a deploy issue relating to ordering of tags which we will come back to.

@mobaig it would be great if you can take a look when you have a chance.
https://trello.com/c/BQDQ824W