### PR TITLE
Rake task to publish organisations to publishing-api

### DIFF
--- a/lib/tasks/lead_organisation_publisher.rake
+++ b/lib/tasks/lead_organisation_publisher.rake
@@ -1,0 +1,22 @@
+namespace :publishing_api do
+  desc "populate publishing api with lead organisations"
+  task publish_lead_organisations: :environment do
+    Policy.find_each do |policy|
+
+      links_payload = {
+        links: {
+          organisations: policy.organisation_content_ids
+        }
+      }
+
+      lead_organisation = policy.organisation_content_ids.first
+
+      if lead_organisation
+        links_payload[:links][:lead_organisations] = [ lead_organisation ]
+      end
+
+      puts "Publishing '#{policy.name}' orgs to publishing-api"
+      Services.publishing_api.put_links(policy.content_id, links_payload)
+    end
+  end
+end


### PR DESCRIPTION
We are migrating this app to use publishing-api's V2 endpoints. This rake task
is for registering the first organisation of each policy as lead organisation in
the publishing api.

We're also taking the opportunity to republish the whole lot of policy
organisations to publishing api just to make sure its database is in sync with
the one used by policy-publisher.

Part of:
https://trello.com/c/BQDQ824W/468-use-publishing-api-v2-for-policy-publisher

Done with: @Davidslv 
cc: @rboulton  @MatMoore 