### PR TITLE
Fetches policy organisations from database

### DIFF
--- a/lib/tasks/lead_organisation_publisher.rake
+++ b/lib/tasks/lead_organisation_publisher.rake
@@ -3,13 +3,15 @@ namespace :publishing_api do
   task publish_lead_organisations: :environment do
     Policy.find_each do |policy|
 
+      organisations_from_db = policy[:organisation_content_ids]
+
       links_payload = {
         links: {
-          organisations: policy.organisation_content_ids
+          organisations: organisations_from_db
         }
       }
 
-      lead_organisation = policy.organisation_content_ids.first
+      lead_organisation = organisations_from_db.first
 
       if lead_organisation
         links_payload[:links][:lead_organisations] = [ lead_organisation ]


### PR DESCRIPTION
When we merged https://github.com/alphagov/policy-publisher/pull/123  we stopped fetching the `organisation_content_ids` from the database,
so when we ran the rake task on https://github.com/alphagov/policy-publisher/pull/124 we sent a list of empty organisations to publishing-api.

This commit changes the behaviour and fetches the `organisation_content_ids` directly from the database.

cc: @rboulton @MatMoore 