### PR TITLE
Updates Admin Frontend

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -3,7 +3,7 @@
 //= require_directory .
 
 $(function () {
-  $(".select2").selectize({plugins: ['drag_drop', 'remove_button'], closeAfterSelect: true });
+  $(".select2").selectize({plugins: ['remove_button'], closeAfterSelect: true });
 
   $(".applicable-nations input[type='checkbox']").click(function() {
     $('.js-alternative-policy-url#' + $(this).data('nation')).toggle();

--- a/app/controllers/policies_controller.rb
+++ b/app/controllers/policies_controller.rb
@@ -17,7 +17,7 @@ class PoliciesController < ApplicationController
       flash[:success] = "Successfully created a policy"
       redirect_to policies_path
     else
-      flash[:danger] = "Could not create the policy : #{policy_form.error_message}"
+      flash[:danger] = "Could not create the policy : #{policy_form.error_messages}"
       @policy_form = policy_form
       render :new
     end
@@ -34,7 +34,7 @@ class PoliciesController < ApplicationController
 
       redirect_to policies_path
     else
-      flash[:danger] = "Could not update the policy: #{policy.errors.full_messages.to_sentence.downcase}"
+      flash[:danger] = "Could not update the policy: #{policy_form.error_messages}"
 
       @policy_form = policy_form
       render :new

--- a/app/forms/policy_form.rb
+++ b/app/forms/policy_form.rb
@@ -24,7 +24,7 @@ class PolicyForm
 
   attr_accessor(*ATTRIBUTES)
   attr_accessor(*LINK_ATTRIBUTES)
-  attr_accessor :policy
+  attr_writer :policy
 
   include ActiveModel::Model
 
@@ -81,7 +81,7 @@ class PolicyForm
   end
 
   def save
-    return unless self.policy.valid? || valid?
+    return unless valid?
 
     attributes = as_json(only: ATTRIBUTES)
 

--- a/app/forms/policy_form.rb
+++ b/app/forms/policy_form.rb
@@ -28,8 +28,8 @@ class PolicyForm
 
   include ActiveModel::Model
 
+  validates_presence_of :name, :description
   validate :validate_organisations
-  validates_presence_of :lead_organisation_content_ids, :name, :description
 
   def validate_organisations
     lead       = self.lead_organisation_content_ids.to_set

--- a/app/forms/policy_form.rb
+++ b/app/forms/policy_form.rb
@@ -29,6 +29,7 @@ class PolicyForm
   include ActiveModel::Model
 
   validate :validate_organisations
+  validates_presence_of :lead_organisation_content_ids, :name, :description
 
   def validate_organisations
     lead       = self.lead_organisation_content_ids.to_set
@@ -80,6 +81,8 @@ class PolicyForm
   end
 
   def save
+    return unless self.policy.valid? || valid?
+
     attributes = as_json(only: ATTRIBUTES)
 
     policy.set_organisation_priority(@lead_organisation_content_ids, @supporting_organisation_content_ids)
@@ -89,8 +92,8 @@ class PolicyForm
     policy.update_attributes(attributes) && publish!
   end
 
-  def error_message
-    policy.errors.full_messages.to_sentence.downcase
+  def error_messages
+    errors.full_messages.to_sentence.downcase.sub('lead organisation content ids', 'organisations')
   end
 
   def policy

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -40,30 +40,20 @@ module ApplicationHelper
     Policy.areas.map { |policy| [policy.name, policy.id] }
   end
 
-  # Re-orders the data container such that +selected+ ones appear first.
+  # Re-orders the data container such that +selected+ ones appear first.
+  # and both in alphabetical order
   def prioritise_data_container(unprioritised_container, selected)
+    selected_items = []
 
-    # extract selected names
-    # don't follow this approach as select is more expensive in a big list (compared to detect)
-    selected_orgs = unprioritised_container.select { |item| selected.include?(item[1]) }.map(&:first)
-
-    # sort them
-    selected_orgs.sort!
-
-
-    # put them in the beggining of the list
-    # the problem is that you need to remove the selected ones from the
-    # unprioritised_container before adding them to the begginning of the list
-
-    selected.reverse.each do |value|
-      if item = unprioritised_container.detect { |item| item[1] == value }
-        unprioritised_container.delete(item)
-        unprioritised_container.unshift(item)
+    unselected_items = unprioritised_container.each do |item|
+      selected.each do |selected_item|
+        if item[1] == selected_item
+          selected_items << item
+          unprioritised_container.delete(item)
+        end
       end
     end
 
-
-
-    unprioritised_container
+    (selected_items.sort + unselected_items)
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -42,12 +42,27 @@ module ApplicationHelper
 
   # Re-orders the data container such that +selected+ ones appear first.
   def prioritise_data_container(unprioritised_container, selected)
+
+    # extract selected names
+    # don't follow this approach as select is more expensive in a big list (compared to detect)
+    selected_orgs = unprioritised_container.select { |item| selected.include?(item[1]) }.map(&:first)
+
+    # sort them
+    selected_orgs.sort!
+
+
+    # put them in the beggining of the list
+    # the problem is that you need to remove the selected ones from the
+    # unprioritised_container before adding them to the begginning of the list
+
     selected.reverse.each do |value|
       if item = unprioritised_container.detect { |item| item[1] == value }
         unprioritised_container.delete(item)
         unprioritised_container.unshift(item)
       end
     end
+
+
 
     unprioritised_container
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -15,45 +15,4 @@ module ApplicationHelper
       end
     end
   end
-
-  # Data container used to generate the options for an organisations select field
-  def organisations_data_container
-    ContentItemFetcher.new.organisations
-      .sort_by { |organisation| organisation['title'] }
-      .map { |org| [org['title'], org['content_id']] }
-  end
-
-  # Data container used to generate the options for a people select field
-  def people_data_container
-    ContentItemFetcher.new.people
-      .sort_by { |person| person['title'] }
-      .map { |person| [person['title'], person['content_id']] }
-  end
-
-  def working_groups_data_container
-    ContentItemFetcher.new.working_groups
-      .sort_by { |working_group| working_group['title'] }
-      .map { |wg| [wg['title'], wg['content_id']] }
-  end
-
-  def policies_areas_data_container
-    Policy.areas.map { |policy| [policy.name, policy.id] }
-  end
-
-  # Re-orders the data container such that +selected+ ones appear first.
-  # and both in alphabetical order
-  def prioritise_data_container(unprioritised_container, selected)
-    selected_items = []
-
-    unselected_items = unprioritised_container.each do |item|
-      selected.each do |selected_item|
-        if item[1] == selected_item
-          selected_items << item
-          unprioritised_container.delete(item)
-        end
-      end
-    end
-
-    (selected_items.sort + unselected_items)
-  end
 end

--- a/app/helpers/data_for_select_helper.rb
+++ b/app/helpers/data_for_select_helper.rb
@@ -1,0 +1,47 @@
+module DataForSelectHelper
+  # Re-orders the data container such that +selected+ ones appear first.
+  # and both in alphabetical order
+  def prioritise_data_container(unprioritised_container, selected)
+    return unprioritised_container if selected.empty?
+
+    selected_items = []
+
+    unselected_items = unprioritised_container.each do |item|
+      selected.each do |selected_item|
+        if item[1] == selected_item
+          selected_items << item
+          unprioritised_container.delete(item)
+        end
+      end
+    end
+
+    (selected_items.sort + unselected_items)
+  end
+
+  # Generates options for an organisations select field
+  def organisations_data_container
+    ContentItemFetcher.new.organisations
+      .sort_by { |organisation| organisation['title'] }
+      .map { |org| [org['title'], org['content_id']] }
+  end
+
+  # Generates options for the people select field
+  def people_data_container
+    ContentItemFetcher.new.people
+      .sort_by { |person| person['title'] }
+      .map { |person| [person['title'], person['content_id']] }
+  end
+
+  # Generates options for the working groups select field
+  def working_groups_data_container
+    ContentItemFetcher.new.working_groups
+      .sort_by { |working_group| working_group['title'] }
+      .map { |wg| [wg['title'], wg['content_id']] }
+  end
+
+
+  # Generates options for the policy areas select field
+  def policies_areas_data_container
+    Policy.areas.map { |policy| [policy.name, policy.id] }
+  end
+end

--- a/app/views/policies/_form.html.erb
+++ b/app/views/policies/_form.html.erb
@@ -6,10 +6,10 @@
 
   <%= form.select :lead_organisation_content_ids,
         prioritise_data_container(organisations_data_container, policy_form.lead_organisation_content_ids),
-        { label: "Lead organisations" },
+        { label: "Organisations" },
         { multiple: true,
           class: 'select2',
-          data: { placeholder: 'Choose lead organisations…' } } %>
+          data: { placeholder: 'Choose organisations…' } } %>
 
   <%= form.select :supporting_organisation_content_ids,
         prioritise_data_container(organisations_data_container, policy_form.supporting_organisation_content_ids),

--- a/features/support/policy_helpers.rb
+++ b/features/support/policy_helpers.rb
@@ -76,7 +76,7 @@ module PolicyHelpers
 
   def associate_policy_with_organisation(policy:, organisation_name:)
     visit_policy(policy)
-    select organisation_name, from: "Lead organisations"
+    select organisation_name, from: "Organisations"
     click_on "Save"
   end
 

--- a/spec/forms/policy_form_spec.rb
+++ b/spec/forms/policy_form_spec.rb
@@ -1,16 +1,26 @@
 require 'rails_helper'
 
 RSpec.describe PolicyForm do
+  include PublishingApiContentHelpers
+
+  before do
+    stub_content_calls_from_publishing_api
+    stub_any_publishing_api_write
+    stub_any_publishing_api_publish
+    stub_post_to_search
+  end
+
+  let(:attributes) do
+    {
+      name: 'A Policy',
+      description: 'A Policy description',
+      lead_organisation_content_ids: [],
+      supporting_organisation_content_ids: [],
+    }
+  end
 
   context 'validations' do
     context 'when organisations' do
-      let(:attributes) do
-        {
-          lead_organisation_content_ids: [],
-          supporting_organisation_content_ids: [],
-        }
-      end
-
       it 'should not have lead organisations that are also supporting organisations' do
         set_organisation_attributes([1], [1,2,3])
 
@@ -51,16 +61,8 @@ RSpec.describe PolicyForm do
 
       it 'valid to have no organisations' do
         policy_form = PolicyForm.new(attributes)
-        policy_form.save
 
         expect(policy_form.valid?).to be_truthy
-      end
-
-    private 
-      def set_organisation_attributes(lead = [], supporting = [])
-        attributes.merge!(
-          lead_organisation_content_ids: lead,
-          supporting_organisation_content_ids: supporting)
       end
     end
   end
@@ -93,7 +95,7 @@ RSpec.describe PolicyForm do
 
   describe '#save' do
     it 'passes through people content ids to the model' do
-      policy_form = PolicyForm.new(people_content_ids: [1, 2, 3])
+      policy_form = PolicyForm.new(attributes.merge(people_content_ids: [1, 2, 3]))
       policy_form.save
 
       expect(policy_form.policy.people_content_ids).to eql [1, 2, 3]
@@ -101,17 +103,14 @@ RSpec.describe PolicyForm do
 
     it 'passes through name to the model' do
       policy_name = "Free ice cream"
-      policy_form = PolicyForm.new(name: policy_name)
+      policy_form = PolicyForm.new(attributes.merge(name: policy_name))
       policy_form.save
 
       expect(policy_form.policy.name).to eql policy_name
     end
 
     it 'combines lead and supporting organisations into organisations on the policy model' do
-      attributes = {
-        lead_organisation_content_ids: [1, 2],
-        supporting_organisation_content_ids: [3, 4],
-      }
+      set_organisation_attributes([1, 2], [3, 4])
 
       policy_form = PolicyForm.new(attributes)
       policy_form.save
@@ -119,5 +118,12 @@ RSpec.describe PolicyForm do
 
       expect(policy.organisation_content_ids).to eql [1,2,3,4]
     end
+  end
+
+private
+  def set_organisation_attributes(lead = [], supporting = [])
+    attributes.merge!(
+      lead_organisation_content_ids: lead,
+      supporting_organisation_content_ids: supporting)
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -28,5 +28,11 @@ RSpec.describe ApplicationHelper, type: :helper do
         helper.prioritise_data_container(unprioritised_container, selected)
       ).to eq(expected)
     end
+
+    it 'returns the unprioritised_container without selected' do
+      expect(
+        helper.prioritise_data_container(unprioritised_container, [])
+      ).to eq(unprioritised_container)
+    end
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe ApplicationHelper, type: :helper do
+  let(:youth_content_id)  { "47336035-23b3-4d3c-b167-195e820240b2" }
+  let(:animal_content_id) { "06d8614b-ceea-46b2-8f04-f8d73d8eeef2" }
+
+  let(:selected) { [youth_content_id, animal_content_id] }
+
+  let(:unprioritised_container) do
+    [
+      ["Ancient", "af539468-c8df-487c-987f-f737dce181eb"],
+      ["Animal", animal_content_id],
+      ["Water", "cef82b42-a8a0-45c9-b204-259ec464c1c3"],
+      ["Youth", youth_content_id],
+    ]
+  end
+
+  describe '#prioritise_data_container' do
+    it 'sorts the data in alphabetical order' do
+      expected = [
+        ["Animal", animal_content_id],
+        ["Youth", youth_content_id],
+        ["Ancient", "af539468-c8df-487c-987f-f737dce181eb"],
+        ["Water", "cef82b42-a8a0-45c9-b204-259ec464c1c3"],
+      ]
+
+      expect(
+        helper.prioritise_data_container(unprioritised_container, selected)
+      ).to eq(expected)
+    end
+  end
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,38 +1,21 @@
 require 'rails_helper'
 
 RSpec.describe ApplicationHelper, type: :helper do
-  let(:youth_content_id)  { "47336035-23b3-4d3c-b167-195e820240b2" }
-  let(:animal_content_id) { "06d8614b-ceea-46b2-8f04-f8d73d8eeef2" }
+  describe '#policy_type' do
+    context 'when is not a sub policy' do
+      it 'returns "policy"' do
+        policy = create :policy
 
-  let(:selected) { [youth_content_id, animal_content_id] }
-
-  let(:unprioritised_container) do
-    [
-      ["Ancient", "af539468-c8df-487c-987f-f737dce181eb"],
-      ["Animal", animal_content_id],
-      ["Water", "cef82b42-a8a0-45c9-b204-259ec464c1c3"],
-      ["Youth", youth_content_id],
-    ]
-  end
-
-  describe '#prioritise_data_container' do
-    it 'sorts the data in alphabetical order' do
-      expected = [
-        ["Animal", animal_content_id],
-        ["Youth", youth_content_id],
-        ["Ancient", "af539468-c8df-487c-987f-f737dce181eb"],
-        ["Water", "cef82b42-a8a0-45c9-b204-259ec464c1c3"],
-      ]
-
-      expect(
-        helper.prioritise_data_container(unprioritised_container, selected)
-      ).to eq(expected)
+        expect(helper.policy_type(policy)).to eq('policy')
+      end
     end
 
-    it 'returns the unprioritised_container without selected' do
-      expect(
-        helper.prioritise_data_container(unprioritised_container, [])
-      ).to eq(unprioritised_container)
+    context 'when is a sub policy' do
+      it 'returns "sub-policy"' do
+        policy = create :sub_policy
+
+        expect(helper.policy_type(policy)).to eq('sub-policy')
+      end
     end
   end
 end

--- a/spec/helpers/data_for_select_helper_spec.rb
+++ b/spec/helpers/data_for_select_helper_spec.rb
@@ -1,0 +1,91 @@
+require 'rails_helper'
+
+RSpec.describe DataForSelectHelper, type: :helper do
+  def stub_publishing_api(status:, body:)
+    stub_request(:get, %r{#{Plek.find('publishing-api')}/v2/content}).
+      to_return(status: status, body: body)
+  end
+
+  def build_response_body(titles: [])
+    titles.map! do |title|
+      {'content_id' => SecureRandom.uuid, 'title' => title}
+    end
+
+    titles.to_json
+  end
+
+  describe '#prioritise_data_container' do
+    let(:youth_content_id)  { "47336035-23b3-4d3c-b167-195e820240b2" }
+    let(:animal_content_id) { "06d8614b-ceea-46b2-8f04-f8d73d8eeef2" }
+
+    let(:unprioritised_container) do
+      [
+        ["Ancient", "af539468-c8df-487c-987f-f737dce181eb"],
+        ["Animal", animal_content_id],
+        ["Water", "cef82b42-a8a0-45c9-b204-259ec464c1c3"],
+        ["Youth", youth_content_id],
+      ]
+    end
+
+    context 'when has selected items' do
+      let(:selected) { [youth_content_id, animal_content_id] }
+
+      it 'sorts the selected items and moves them to the top of the list' do
+        expected = [
+          ["Animal", animal_content_id],
+          ["Youth", youth_content_id],
+          ["Ancient", "af539468-c8df-487c-987f-f737dce181eb"],
+          ["Water", "cef82b42-a8a0-45c9-b204-259ec464c1c3"],
+        ]
+
+        expect(
+          helper.prioritise_data_container(unprioritised_container, selected)
+        ).to eq(expected)
+      end
+    end
+
+    context 'when nothing is selected' do
+      let(:selected) { [] }
+
+      it 'returns the unmodified input list' do
+        expect(
+          helper.prioritise_data_container(unprioritised_container, selected)
+        ).to eq(unprioritised_container)
+      end
+    end
+  end
+
+  describe '#organisations_data_container' do
+    it 'returns a list of organisations sorted by title' do
+      titles = %w(Taxes Animal Education)
+      stub_publishing_api(status: 200, body: build_response_body(titles: titles))
+
+      expect(helper.organisations_data_container.map(&:first)).to eql %w(Animal Education Taxes)
+    end
+  end
+
+  describe '#people_data_container' do
+    it 'returns a list of people sorted by title' do
+      titles = %w(Zoe Ana Henry)
+      stub_publishing_api(status: 200, body: build_response_body(titles: titles))
+
+      expect(helper.people_data_container.map(&:first)).to eql %w(Ana Henry Zoe)
+    end
+  end
+
+  describe '#working_groups_data_container' do
+    it 'returns a list of working groups sorted by title' do
+      titles = %w(Z B C)
+      stub_publishing_api(status: 200, body: build_response_body(titles: titles))
+
+      expect(helper.people_data_container.map(&:first)).to eql %w(B C Z)
+    end
+  end
+
+  describe '#policies_areas_data_container' do
+    it 'returns a list of policy areas with name and id' do
+      policy = create :policy
+      expect(helper.policies_areas_data_container).to eql([[policy.name, policy.id]])
+    end
+  end
+end

--- a/spec/support/publishing_api_content_helpers.rb
+++ b/spec/support/publishing_api_content_helpers.rb
@@ -13,12 +13,36 @@ module PublishingApiContentHelpers
     stub_request(:post, %r{\A#{PUBLISHING_API_V2_ENDPOINT}/content/})
   end
 
+  def stub_post_to_search
+    stub_request(:post, "#{Plek.find("search")}/documents")
+  end
+
   def stub_content_calls_from_publishing_api
     fields = %w(content_id format title base_path)
+    publishing_api_has_fields_for_format("lead_organisation", [lead_organisation_1, lead_organisation_2], fields)
     publishing_api_has_fields_for_format("organisation", [organisation_1, organisation_2], fields)
     publishing_api_has_fields_for_format("person", [person_1, person_2], fields)
     publishing_api_has_fields_for_format("working_group", [working_group_1, working_group_2], fields)
   end
+
+  def lead_organisation_1
+    @lead_organisation_1 ||= {
+      "content_id" => SecureRandom.uuid,
+      "format" => "lead_organisation",
+      "title" => "Lead Organisation 1",
+      "base_path" => "/government/organisations/lead-organisation-1",
+    }
+  end
+
+  def lead_organisation_2
+    @lead_organisation_2 ||= {
+      "content_id" => SecureRandom.uuid,
+      "format" => "lead_organisation",
+      "title" => "Lead Organisation 2",
+      "base_path" => "/government/organisations/lead-organisation-1",
+    }
+  end
+
 
   def organisation_1
     @organisation_1 ||= {


### PR DESCRIPTION
Story: https://trello.com/c/BQDQ824W/468-use-publishing-api-v2-for-policy-publisher
- Fixes bug with error messages, where the right ones where not being shown
- Changes method on ApplicationHelper, `prioritise_data_container` to return data in alphabetical order
- Corrects failing spec to represent calls to the Publishing API
- Removes drag and drop from input fields as order is not mantained