### PR TITLE
Update policy-publisher to use the new subscriber_list details format

### DIFF
--- a/app/presenters/email_alert_signup_content_item_presenter.rb
+++ b/app/presenters/email_alert_signup_content_item_presenter.rb
@@ -44,8 +44,10 @@ private
       email_alert_type: "policies",
       breadcrumbs: breadcrumbs,
       summary: summary,
-      signup_tags: {
-        policies: [policy.slug],
+      subscriber_list: {
+        tags: {
+          policies: [policy.slug],
+        }
       },
       govdelivery_title: "#{policy.name} policy",
     }

--- a/spec/presenters/email_alert_signup_content_item_presenter_spec.rb
+++ b/spec/presenters/email_alert_signup_content_item_presenter_spec.rb
@@ -11,11 +11,13 @@ RSpec.describe EmailAlertSignupContentItemPresenter do
     it "includes appropriate tags to get the subscriptions URL" do
       policy = FactoryGirl.create(:policy)
       presenter = EmailAlertSignupContentItemPresenter.new(policy)
-      signup_tags = {
-        "policies" => [policy.slug]
+      expected_subscriber_list = {
+        "tags" => {
+          "policies" => [policy.slug]
+        }
       }
 
-      expect(presenter.exportable_attributes.as_json['details']["signup_tags"]).to eq(signup_tags)
+      expect(presenter.exportable_attributes.as_json['details']["subscriber_list"]).to eq(expected_subscriber_list)
     end
 
     it "includes breadcrumbs with the relevant policy" do


### PR DESCRIPTION
**We will merge the pull requests ourselves in the Publishing Platform team when everyone's happy.**

https://trello.com/c/oqGCU2XP/525-add-email-signup-links-to-travel-advice-on-frontend

We've been migrating travel advice over to use the new email-alert-frontend workflow rather than the old pagewatch workflow.

Whilst doing this work, we noticed that policy publisher passes through subscriber list information as implicit links on the signup content item (which should really be reserved for more general associations with other content items). After talking with @tijmenb and @mobaig in Finding Things we concluded that the details hash is the best place for that information.

Therefore, this work consists of four parts:

1) An update to travel advice publisher to create the new email alert signup forms
https://github.com/alphagov/travel-advice-publisher/pull/123

2) An update to policy publisher to change the structure of the subscriber list data
https://github.com/alphagov/policy-publisher/pull/129

3) An update the email-alert-frontend to support searching by document_type (required for travel index)
https://github.com/alphagov/email-alert-frontend/pull/25

4) An update to the content schemas to reflect the new subscriber list data structure
https://github.com/alphagov/govuk-content-schemas/pull/261

We'd like to merge and deploy all four pull requests at (roughly) the same time. Please could comment as usual and state whether you are happy for the pull requests to be merged.