### PR TITLE
Remove broken rake task

### DIFF
--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -1,12 +1,4 @@
 namespace :publishing_api do
-  desc "Publish all Policies to the Publishing API in reverse alphabetical order"
-  task publish_policies: :environment do
-    Policy.all.order("name DESC").each { |policy|
-      puts "Publishing #{policy.name}"
-      Publisher.new(policy).publish!
-    }
-  end
-
   desc "Publish the Policies Finder to the Publishing API"
   task publish_policies_finder: :environment do
     require "policies_finder_publisher"


### PR DESCRIPTION
This task was written when we still had links in the local db.

This won't work now, and if run would remove links from the publishing api.

Temporarily remove this, to allow us to fix the root cause.