### PR TITLE
Retire redundant policy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem 'govuk_admin_template', '~> 3.5'
 gem 'generic_form_builder', '0.13.0'
 gem 'selectize-rails', '~> 0.12.1'
 
-gem 'gds-api-adapters', '~> 29.3'
+gem 'gds-api-adapters', '~> 30.4'
 
 gem 'govspeak','3.3.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,7 +78,7 @@ GEM
     database_cleaner (1.5.1)
     debug_inspector (0.0.2)
     diff-lcs (1.2.5)
-    domain_name (0.5.20160216)
+    domain_name (0.5.20160310)
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.6.0)
@@ -89,7 +89,7 @@ GEM
       railties (>= 3.0.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
-    gds-api-adapters (29.3.1)
+    gds-api-adapters (30.4.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -306,7 +306,7 @@ DEPENDENCIES
   cucumber-rails
   database_cleaner
   factory_girl_rails
-  gds-api-adapters (~> 29.3)
+  gds-api-adapters (~> 30.4)
   gds-sso (~> 11.2)
   generic_form_builder (= 0.13.0)
   govspeak (= 3.3.0)

--- a/db/migrate/20160601111826_unpublish_redundant_policy.rb
+++ b/db/migrate/20160601111826_unpublish_redundant_policy.rb
@@ -1,0 +1,12 @@
+class UnpublishRedundantPolicy < ActiveRecord::Migration
+  def up
+    Services.publishing_api.unpublish(
+      "f656d065-43aa-4ab0-91f7-a6809ce5b68b",
+      type: "gone",
+      discard_drafts: true,
+    )
+  end
+
+  def down
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160525154825) do
+ActiveRecord::Schema.define(version: 20160601111826) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
Meant as an alternative to https://github.com/alphagov/publishing-api/pull/286.

@elliotcm 👍 on [the docs](http://www.rubydoc.info/github/alphagov/gds-api-adapters/master/GdsApi/PublishingApiV2#unpublish-instance_method), super useful.
