### PR TITLE
Add `emphasised_organisations` to details

### DIFF
--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -73,6 +73,7 @@ private
       summary: summary,
       show_summaries: false,
       facets: facets,
+      emphasised_organisations: policy.lead_organisation_content_ids,
     }
 
     details.merge(nation_applicability).merge(internal_name)

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -1,4 +1,17 @@
 namespace :publishing_api do
+  desc "Publish all Policies to the Publishing API in reverse alphabetical order"
+  task publish_policies: :environment do
+    Policy.all.order("name DESC").each do |policy|
+      puts "Publishing #{policy.name}"
+
+      # Load the links from publishing-api, because we don't keep those in the
+      # application database.
+      policy.fetch_links!
+
+      Publisher.new(policy).publish!
+    end
+  end
+
   desc "Publish the Policies Finder to the Publishing API"
   task publish_policies_finder: :environment do
     require "policies_finder_publisher"

--- a/spec/presenters/content_item_presenter_spec.rb
+++ b/spec/presenters/content_item_presenter_spec.rb
@@ -81,5 +81,14 @@ RSpec.describe ContentItemPresenter do
       sub_policy = FactoryGirl.create(:sub_policy, parent_policies: [policy])
       expect(ContentItemPresenter.new(sub_policy).exportable_attributes[:details][:internal_name]).to eq("#{sub_policy.name}: #{policy.name}")
     end
+
+    it "includes the emphasised_organisations" do
+      policy = create(:policy)
+      policy.lead_organisation_content_ids = [1, 2, 3]
+
+      payload = ContentItemPresenter.new(policy).exportable_attributes
+
+      expect(payload[:details][:emphasised_organisations]).to eql([1, 2, 3])
+    end
   end
 end


### PR DESCRIPTION
This will be used to show some organisations higher in the list of publishing/owning organisations on the frontend.

See:

https://github.com/alphagov/govuk-content-schemas#306
https://github.com/alphagov/govuk-content-schemas#307

After we've deployed this and migrated the frontend we're going to have to make a PR here to remove `lead_organisations`. At that point we should also refactor some of the code here. In particular the way the data flows from the form to publishing-api needs reworking. We already have a ticket in our backlog to do this (https://trello.com/c/OAXUsVM9/293-refactor-policy-publisher). 