### PR TITLE
Make republish rake task more specific

### DIFF
--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -8,7 +8,7 @@ namespace :publishing_api do
       # application database.
       policy.fetch_links!
 
-      Publisher.new(policy).publish!
+      ContentItemPublisher.new(policy, update_type: 'republish').publish!
     end
   end
 


### PR DESCRIPTION
This rake task is doing four things at the moment: republish the policy, the email signup page for the policy, the parent policy and sends the data to rummager. We only want it to send the policy to the
publishing-api. This also allows us to specify the `update_type`, which will prevent emails from being sent out.

This should fix an issue where we can't republish the items because publishing API is too slow.

Trello: https://trello.com/c/us3MI1n9/602-fix-organisation-tagging