### PR TITLE
Fix bug in rake task

### DIFF
--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -8,7 +8,7 @@ namespace :publishing_api do
       # application database.
       policy.fetch_links!
 
-      ContentItemPublisher.new(policy, update_type: 'republish').publish!
+      ContentItemPublisher.new(policy, update_type: 'republish').run!
     end
   end
 


### PR DESCRIPTION
https://github.com/alphagov/policy-publisher/pull/135 changed this rake task. The interface of `ContentItemPublisher` is different from `Publisher`, so this did not work.

This is tested on development:

```
vagrant@development:~/govuk/policy-publisher$ be rake publishing_api:publish_policies
Publishing Young people
```