### PR TITLE
Remove `organisation_content_ids` from database

### DIFF
--- a/db/migrate/20160525142802_remove_organisation_ids.rb
+++ b/db/migrate/20160525142802_remove_organisation_ids.rb
@@ -1,0 +1,5 @@
+class RemoveOrganisationIds < ActiveRecord::Migration
+  def change
+    remove_column :policies, :organisation_content_ids
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160104161439) do
+ActiveRecord::Schema.define(version: 20160525142802) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +21,7 @@ ActiveRecord::Schema.define(version: 20160104161439) do
     t.string   "name"
     t.text     "description"
     t.string   "content_id"
+    t.text     "people_content_ids",            default: [],                array: true
     t.boolean  "england",                       default: true
     t.string   "england_policy_url"
     t.boolean  "northern_ireland",              default: true
@@ -32,8 +33,6 @@ ActiveRecord::Schema.define(version: 20160104161439) do
     t.datetime "created_at",                                   null: false
     t.datetime "updated_at",                                   null: false
     t.string   "email_alert_signup_content_id"
-    t.text     "organisation_content_ids",      default: [],                array: true
-    t.text     "people_content_ids",            default: [],                array: true
     t.text     "working_group_content_ids",     default: [],                array: true
   end
 


### PR DESCRIPTION
This has not been used since https://github.com/alphagov/policy-publisher/pull/123.