### PR TITLE
Remove unused columns from policies table

### DIFF
--- a/db/migrate/20160525154825_remove_links_columns.rb
+++ b/db/migrate/20160525154825_remove_links_columns.rb
@@ -1,0 +1,6 @@
+class RemoveLinksColumns < ActiveRecord::Migration
+  def change
+    remove_column :policies, :working_group_content_ids
+    remove_column :policies, :people_content_ids
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160525142802) do
+ActiveRecord::Schema.define(version: 20160525154825) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,7 +21,6 @@ ActiveRecord::Schema.define(version: 20160525142802) do
     t.string   "name"
     t.text     "description"
     t.string   "content_id"
-    t.text     "people_content_ids",            default: [],                array: true
     t.boolean  "england",                       default: true
     t.string   "england_policy_url"
     t.boolean  "northern_ireland",              default: true
@@ -33,7 +32,6 @@ ActiveRecord::Schema.define(version: 20160525142802) do
     t.datetime "created_at",                                   null: false
     t.datetime "updated_at",                                   null: false
     t.string   "email_alert_signup_content_id"
-    t.text     "working_group_content_ids",     default: [],                array: true
   end
 
   add_index "policies", ["email_alert_signup_content_id"], name: "index_policies_on_email_alert_signup_content_id", unique: true, using: :btree


### PR DESCRIPTION
These have not been used since https://github.com/alphagov/policy-publisher/pull/137 and can be safely removed.