### PR TITLE
[wip]Extract policy linkset

### DIFF
--- a/app/controllers/policies_controller.rb
+++ b/app/controllers/policies_controller.rb
@@ -45,8 +45,6 @@ private
 
   def policy
     @policy ||= Policy.find(params[:id])
-    @policy.fetch_links!
-    @policy
   end
 
   def policy_params

--- a/app/forms/policy_form.rb
+++ b/app/forms/policy_form.rb
@@ -15,6 +15,7 @@ class PolicyForm
     parent_policy_ids
   ]
 
+# should load this from the policylinkset item
   LINK_ATTRIBUTES = %w[
     lead_organisation_content_ids
     supporting_organisation_content_ids

--- a/app/models/policy.rb
+++ b/app/models/policy.rb
@@ -1,3 +1,38 @@
+class PolicyLinkset
+  attr_accessor :organisation_content_ids,
+                :lead_organisation_content_ids,
+                :people_content_ids,
+                :working_group_content_ids
+
+  def initialize
+    organisation_content_ids = []
+    lead_organisation_content_ids = []
+    people_content_ids = []
+    working_group_content_ids = []
+  end
+
+# refactor and rename
+  def initialize_from_policy(content_id)
+    new if content_id.blank?
+
+    links = Services.publishing_api.get_links(content_id)["links"]
+
+    lead_organisation_content_ids = links["lead_organisations"] || []
+    organisation_content_ids = links["organisations"] || []
+    people_content_ids = links["people"] || []
+    working_group_content_ids = links["working_groups"] || []
+  end
+
+  def set_organisation_priority(lead_organisation_content_ids, supporting_organisation_content_ids)
+    lead_organisation_content_ids = lead_organisation_content_ids
+    organisation_content_ids = lead_organisation_content_ids + supporting_organisation_content_ids
+  end
+
+  def supporting_organisation_content_ids
+    organisation_content_ids - lead_organisation_content_ids
+  end
+end
+
 class Policy < ActiveRecord::Base
   validates :content_id, presence: true, uniqueness: true
   validates :name, :slug, presence: true, uniqueness: true
@@ -30,16 +65,17 @@ class Policy < ActiveRecord::Base
   end
   alias_method :sub_policy?, :sub_policy
 
-  attr_accessor :organisation_content_ids
-  attr_accessor :lead_organisation_content_ids
-  attr_accessor :people_content_ids
-  attr_accessor :working_group_content_ids
+  attr_accessor :policy_linkset
+  delegate :organisation_content_ids,
+                :lead_organisation_content_ids,
+                :people_content_ids,
+                :working_group_content_ids,
+                :set_organisation_priority,
+                :supporting_organisation_content_ids,
+                to: :policy_linkset
 
   after_initialize do
-    self.organisation_content_ids ||= []
-    self.lead_organisation_content_ids ||= []
-    self.people_content_ids ||= []
-    self.working_group_content_ids ||= []
+    @policy_linkset = PolicyLinkset.new
   end
 
   def base_path
@@ -61,27 +97,6 @@ class Policy < ActiveRecord::Base
 
   def inapplicable_nations
     possible_nations - applicable_nations
-  end
-
-  # Fetch links from the publisher-api
-  def fetch_links!
-    return if content_id.blank?
-
-    links = Services.publishing_api.get_links(content_id)["links"]
-
-    self.lead_organisation_content_ids = links["lead_organisations"] || []
-    self.organisation_content_ids = links["organisations"] || []
-    self.people_content_ids = links["people"] || []
-    self.working_group_content_ids = links["working_groups"] || []
-  end
-
-  def set_organisation_priority(lead_organisation_content_ids, supporting_organisation_content_ids)
-    self.lead_organisation_content_ids = lead_organisation_content_ids
-    self.organisation_content_ids = lead_organisation_content_ids + supporting_organisation_content_ids
-  end
-
-  def supporting_organisation_content_ids
-    organisation_content_ids - lead_organisation_content_ids
   end
 
 private

--- a/app/models/policy_linkset.rb
+++ b/app/models/policy_linkset.rb
@@ -1,0 +1,42 @@
+class PolicyLinkset
+  attr_accessor :organisation_content_ids,
+                :lead_organisation_content_ids,
+                :people_content_ids,
+                :working_group_content_ids
+
+  def initialize(content_id = nil)
+    @organisation_content_ids = []
+    @lead_organisation_content_ids = []
+    @people_content_ids = []
+    @working_group_content_ids = []
+    
+ # TODO refactor into two different methods, ie
+ # def from_existing(policy)
+ #   links = Services.publishing_api.get_links(policy.content_id)["links"]
+ #
+ #   new({
+ #     organisation_content_ids: links["lead_organisations"] || [],
+ #     lead_organisation_content_ids: links["organisations"] || [],
+ #     people_content_ids: links["people"] || [],
+ #     working_group_content_ids: links["working_groups"] || [],
+ #   })
+ # end
+
+    if content_id
+      links = Services.publishing_api.get_links(content_id)["links"]
+      @lead_organisation_content_ids = links["lead_organisations"] || []
+      @organisation_content_ids = links["organisations"] || []
+      @people_content_ids = links["people"] || []
+      @working_group_content_ids = links["working_groups"] || []
+    end
+  end
+
+  def set_organisation_priority(lead_organisation_content_ids, supporting_organisation_content_ids)
+    @lead_organisation_content_ids = lead_organisation_content_ids
+    @organisation_content_ids = lead_organisation_content_ids + supporting_organisation_content_ids
+  end
+
+  def supporting_organisation_content_ids
+    organisation_content_ids - lead_organisation_content_ids
+  end
+end

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -4,10 +4,6 @@ namespace :publishing_api do
     Policy.all.order("name DESC").each do |policy|
       puts "Publishing #{policy.name}"
 
-      # Load the links from publishing-api, because we don't keep those in the
-      # application database.
-      policy.fetch_links!
-
       ContentItemPublisher.new(policy, update_type: 'republish').run!
     end
   end

--- a/spec/forms/policy_form_spec.rb
+++ b/spec/forms/policy_form_spec.rb
@@ -73,6 +73,10 @@ RSpec.describe PolicyForm do
   describe '.from_existing' do
     let(:policy) { FactoryGirl.create(:policy, name: "Climate change") }
 
+    before do
+      stub_has_links(policy)
+    end
+
     it 'loads active record attributes from the policy model' do
       policy_form = PolicyForm.from_existing(policy)
 

--- a/spec/lib/policy_actions/content_item_publisher_spec.rb
+++ b/spec/lib/policy_actions/content_item_publisher_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 require 'gds_api/test_helpers/publishing_api_v2'
 
 RSpec.describe ContentItemPublisher do
-  include GdsApi::TestHelpers::PublishingApiV2
+  include PublishingApiContentHelpers
 
   let(:policy) { create(:policy) }
   let(:content_item_publisher) { ContentItemPublisher.new(policy, update_type: "major") }
@@ -10,6 +10,7 @@ RSpec.describe ContentItemPublisher do
   describe '#run! method' do
     before do
       stub_any_publishing_api_call
+      stub_has_links(policy)
       content_item_publisher.run!
     end
 
@@ -34,6 +35,12 @@ RSpec.describe ContentItemPublisher do
     it "publishes lead organisations and organisations in the links hash" do
       lead       = [SecureRandom.uuid]
       supporting = [SecureRandom.uuid, SecureRandom.uuid]
+
+      stub_has_links(policy, {
+        organisations: lead + supporting,
+        lead_organisations: lead,
+      })
+
       policy.set_organisation_priority(lead, supporting)
 
       links_payload = content_item_publisher.links_payload

--- a/spec/lib/publisher_spec.rb
+++ b/spec/lib/publisher_spec.rb
@@ -3,7 +3,7 @@ require 'gds_api/test_helpers/publishing_api_v2'
 require 'gds_api/test_helpers/rummager'
 
 RSpec.describe Publisher do
-  include GdsApi::TestHelpers::PublishingApiV2
+  include PublishingApiContentHelpers
   include GdsApi::TestHelpers::Rummager
 
   let(:indexer) { double(:indexer) }
@@ -18,6 +18,7 @@ RSpec.describe Publisher do
     let(:policy) { FactoryGirl.create(:policy) }
 
     before do
+      stub_has_links(policy)
       Publisher.new(policy).publish!
     end
 
@@ -42,11 +43,13 @@ RSpec.describe Publisher do
     end
   end
 
-
   context "when publishing a sub-policy" do
     let!(:policy) { FactoryGirl.create(:sub_policy) }
 
     before do
+      # there's something wrong with the moking here
+      parent_policy = policy.parent_policies.first
+      stub_has_links(policy, {parent_policies: [parent_policy]})
       Publisher.new(policy).publish!
     end
 

--- a/spec/presenters/content_item_presenter_spec.rb
+++ b/spec/presenters/content_item_presenter_spec.rb
@@ -1,34 +1,40 @@
 require "rails_helper"
 
 RSpec.describe ContentItemPresenter do
+  include PublishingApiContentHelpers
+
   describe "#exportable_attributes" do
+    before do
+      @policy = FactoryGirl.create(:policy)
+      stub_has_links(@policy)
+    end
     it "validates against the policy schema" do
-      presenter = ContentItemPresenter.new(FactoryGirl.create(:policy))
+      presenter = ContentItemPresenter.new(@policy)
 
       expect(presenter.exportable_attributes.as_json).to be_valid_against_schema('policy')
     end
 
     it "validates against the schema when the policy has a parent policy" do
-      parent_policy = FactoryGirl.create(:policy)
-      presenter = ContentItemPresenter.new(FactoryGirl.create(:policy, parent_policies: [parent_policy]))
+      sub_policy = FactoryGirl.create(:policy, parent_policies: [@policy])
+      stub_has_links(sub_policy, {parent_policies: [@policy]})
+      presenter = ContentItemPresenter.new(sub_policy)
 
       expect(presenter.exportable_attributes.as_json).to be_valid_against_schema('policy')
     end
 
     it "includes an appropriate filter to filter by the policy slug" do
-      policy = FactoryGirl.create(:policy)
-      presenter = ContentItemPresenter.new(policy)
+      # policy = FactoryGirl.create(:policy«»
+      presenter = ContentItemPresenter.new(@policy)
       filter = {
-        "policies" => [policy.slug]
+        "policies" => [@policy.slug]
       }
 
       expect(presenter.exportable_attributes.as_json['details']["filter"]).to eq(filter)
     end
 
     it "turns Govspeak to HTML when exporting" do
-      policy = FactoryGirl.create(:policy)
-      policy.description = "_This_ is some [Govspeak](https://www.gov.uk)."
-      presenter = ContentItemPresenter.new(policy)
+      @policy.description = "_This_ is some [Govspeak](https://www.gov.uk)."
+      presenter = ContentItemPresenter.new(@policy)
 
       expected_html = "<p><em>This</em> is some <a href=\"https://www.gov.uk\">Govspeak</a>.</p>\n"
 
@@ -36,18 +42,21 @@ RSpec.describe ContentItemPresenter do
     end
 
     it "doesn't add nation_applicability if the policy applies to all nations" do
-      policy = FactoryGirl.create(:policy)
-      attributes = ContentItemPresenter.new(policy).exportable_attributes.as_json
+      attributes = ContentItemPresenter.new(@policy).exportable_attributes.as_json
       expect(attributes["details"]).not_to have_key("nation_applicability")
     end
 
     it "returns a list of applicable nations if there are inapplicable nations" do
-      policy = FactoryGirl.create(
-        :policy,
+      links = {
         northern_ireland: false,
         scotland: false,
         wales: false,
+      }
+      policy = FactoryGirl.create(
+        :policy,
+        links,
       )
+      stub_has_links(policy, links)
 
       attributes = ContentItemPresenter.new(policy).exportable_attributes.as_json
       nation_applicability = attributes["details"]["nation_applicability"]
@@ -56,15 +65,19 @@ RSpec.describe ContentItemPresenter do
     end
 
     it "returns a list of alternative policies for other nations if there are alternative policies" do
-      policy = FactoryGirl.create(
-        :policy,
+      links = {
         northern_ireland: false,
         northern_ireland_policy_url: "https://www.example.ni",
         scotland: false,
         scotland_policy_url: "http://www.example.scot",
         wales: false,
         wales_policy_url: "http://example.wales",
+      }
+      policy = FactoryGirl.create(
+        :policy,
+        links
       )
+      stub_has_links(policy, links)
 
       attributes = ContentItemPresenter.new(policy).exportable_attributes.as_json
       nation_applicability = attributes["details"]["nation_applicability"]
@@ -75,18 +88,17 @@ RSpec.describe ContentItemPresenter do
     end
 
     it "includes the internal name if the policy is a sub-policy" do
-      policy = FactoryGirl.create(:policy)
-      expect(ContentItemPresenter.new(policy).exportable_attributes[:details]).not_to have_key(:internal_name)
+      expect(ContentItemPresenter.new(@policy).exportable_attributes[:details]).not_to have_key(:internal_name)
 
-      sub_policy = FactoryGirl.create(:sub_policy, parent_policies: [policy])
-      expect(ContentItemPresenter.new(sub_policy).exportable_attributes[:details][:internal_name]).to eq("#{sub_policy.name}: #{policy.name}")
+      sub_policy = FactoryGirl.create(:sub_policy, parent_policies: [@policy])
+      stub_has_links(sub_policy, parent_policies: [@policy])
+      expect(ContentItemPresenter.new(sub_policy).exportable_attributes[:details][:internal_name]).to eq("#{sub_policy.name}: #{@policy.name}")
     end
 
     it "includes the emphasised_organisations" do
-      policy = create(:policy)
-      policy.lead_organisation_content_ids = [1, 2, 3]
+      @policy.lead_organisation_content_ids = [1, 2, 3]
 
-      payload = ContentItemPresenter.new(policy).exportable_attributes
+      payload = ContentItemPresenter.new(@policy).exportable_attributes
 
       expect(payload[:details][:emphasised_organisations]).to eql([1, 2, 3])
     end

--- a/spec/presenters/links_presenter_spec.rb
+++ b/spec/presenters/links_presenter_spec.rb
@@ -1,23 +1,13 @@
 require "rails_helper"
 
 RSpec.describe LinksPresenter do
-  include GdsApi::TestHelpers::PublishingApiV2
-
-# move to helper
-  def stub_has_links(policy, links = {})
-    links["email_alert_signup"] = [policy.email_alert_signup_content_id]
-    response = {
-      content_id: policy.content_id,
-      links: links,
-    }
-    publishing_api_has_links(response)
-  end
+  include PublishingApiContentHelpers
 
   describe "#exportable_attributes" do
     it "validates against the policy links schema" do
       policy = create(:policy)
       presenter = LinksPresenter.new(policy)
-      stub_has_links(policy, {})
+      stub_has_links(policy)
 
       expect(presenter.exportable_attributes).to be_valid_against_links_schema("policy")
     end

--- a/spec/support/publishing_api_content_helpers.rb
+++ b/spec/support/publishing_api_content_helpers.rb
@@ -104,4 +104,13 @@ module PublishingApiContentHelpers
     }
     stub_request(:get, url).to_return(status: 200, body: links.to_json, headers: {})
   end
+
+  def stub_has_links(policy, links = {})
+    links["email_alert_signup"] = [policy.email_alert_signup_content_id]
+    response = {
+      content_id: policy.content_id,
+      links: links,
+    }
+    publishing_api_has_links(response)
+  end
 end


### PR DESCRIPTION
I’m refactoring the way policy-publisher handles policy-links.
Extracted the links logic into another model so that it’ll be easier to rework how lead/supporting orgs are being sent to the publishing-api.
Not sure about the automatic fetching bit.