### PR TITLE
Add migration to redirect stale placeholders

### DIFF
--- a/db/migrate/20160614093540_unpublish_stale_placeholders.rb
+++ b/db/migrate/20160614093540_unpublish_stale_placeholders.rb
@@ -1,0 +1,18 @@
+class UnpublishStalePlaceholders < ActiveRecord::Migration
+  def change
+    stale_placeholders_hash = {
+      "12a4eb7a-6037-4cc0-aa58-0a4f2fbc5e7f" => "/government/policies/carers-health",
+      "e0deb0ec-e9fc-4308-b8c0-eba4dc92aa83" => "/government/policies/museums-and-galleries",
+      "f656d065-43aa-4ab0-91f7-a6809ce5b68b" => "/government/policies/special-educational-needs-and-disability-send",
+    }
+
+    stale_placeholders_hash.each do |placeholder_content_id, base_path_for_redirect|
+      Services.publishing_api.unpublish(
+        placeholder_content_id,
+        type: "redirect",
+        alternative_path: base_path_for_redirect,
+        discard_drafts: true,
+      )
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160601111826) do
+ActiveRecord::Schema.define(version: 20160614093540) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
Only merge after https://github.com/alphagov/publishing-api/pull/364 is deployed.

During our examination of discrepancies between Rummager
and Publishing API, we found some placeholders that had
apparently been renamed during the policy-publisher migration
but not updated in publishing-api.
This migration redirects them to the new base_paths.

See https://trello.com/c/xARBi6HF