### PR TITLE
[Don't merge] Remove organisations from Rummager payload

### DIFF
--- a/features/support/rummager_helpers.rb
+++ b/features/support/rummager_helpers.rb
@@ -16,7 +16,6 @@ module RummagerHelpers
       description: policy.description,
       link: policy.base_path,
       indexable_content: "",
-      organisations: [],
       public_timestamp: policy.updated_at,
       _type: "policy",
       _id: policy.base_path,

--- a/lib/policy_actions/search_indexer.rb
+++ b/lib/policy_actions/search_indexer.rb
@@ -17,7 +17,6 @@ class SearchIndexer
       link: policy.base_path,
       slug: policy.slug,
       indexable_content: "",
-      organisations: organisations,
       people: people,
       policy_groups: working_groups,
       public_timestamp: policy.updated_at,
@@ -25,11 +24,6 @@ class SearchIndexer
   end
 
 private
-
-  def organisations
-    fetched_organisations = policy.organisation_content_ids.map { |content_id| fetcher.find_organisation(content_id) }.compact
-    get_slugs(fetched_organisations)
-  end
 
   def people
     fetched_people = policy.people_content_ids.map { |content_id| fetcher.find_person(content_id) }.compact

--- a/spec/lib/policy_actions/search_indexer_spec.rb
+++ b/spec/lib/policy_actions/search_indexer_spec.rb
@@ -8,24 +8,8 @@ RSpec.describe SearchIndexer do
 
   before do
     stub_any_rummager_post
-    publishing_api_has_linkables(organisations, document_type: "organisation")
     publishing_api_has_linkables(people, document_type: "person")
     publishing_api_has_linkables(working_groups, document_type: "working_group")
-  end
-
-  let(:organisations) do
-    [
-      {
-        "content_id" => SecureRandom.uuid,
-        "title" => "Organisation 1",
-        "base_path" => "/government/organisations/organisation-1",
-      },
-      {
-        "content_id" => SecureRandom.uuid,
-        "title" => "Organisation 2",
-        "base_path" => "/government/organisations/organisation-2",
-      },
-    ]
   end
 
   let(:people) do
@@ -60,7 +44,6 @@ RSpec.describe SearchIndexer do
 
   it "indexes a a policy with rummager" do
     policy = FactoryGirl.create(:policy,
-      organisation_content_ids: organisations.map {|o| o["content_id"] },
       people_content_ids: people.map {|person| person["content_id"] },
       working_group_content_ids: working_groups.map {|wg| wg["content_id"] },
     )
@@ -72,7 +55,6 @@ RSpec.describe SearchIndexer do
       link: policy.base_path,
       slug: policy.slug,
       indexable_content: "",
-      organisations: ["organisation-1", "organisation-2"],
       people: ["person-1", "person-2"],
       policy_groups: ["working-group-1", "working-group-2"],
       public_timestamp: policy.updated_at,


### PR DESCRIPTION
Why?:

Rummager has recently been updated to fetch links data directly from the
publishing API when indexing a document. Setting links data in the
publishing app is therefore redundant.