### PR TITLE
Use `document_type` and `schema_name`

### DIFF
--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -9,7 +9,8 @@ class ContentItemPresenter
   def exportable_attributes
     {
       base_path: base_path,
-      format: "policy",
+      document_type: "policy",
+      schema_name: "policy",
       title: title,
       description: description,
       public_updated_at: public_updated_at,

--- a/app/presenters/email_alert_signup_content_item_presenter.rb
+++ b/app/presenters/email_alert_signup_content_item_presenter.rb
@@ -7,7 +7,8 @@ class EmailAlertSignupContentItemPresenter
   def exportable_attributes
     {
       base_path: base_path,
-      format: "email_alert_signup",
+      document_type: "email_alert_signup",
+      schema_name: "email_alert_signup",
       title: policy.name,
       description: "",
       public_updated_at: public_updated_at,

--- a/features/step_definitions/policy_steps.rb
+++ b/features/step_definitions/policy_steps.rb
@@ -89,7 +89,8 @@ Then(/^a policy called "(.*?)" is published to publishing API$/) do |policy_name
   assert_publishing_api_put_content(
     policy.content_id,
     request_json_includes(
-      "format" => "policy",
+      "document_type" => "policy",
+      "schema_name" => "policy",
       "rendering_app" => "finder-frontend",
       "publishing_app" => "policy-publisher",
     ),
@@ -119,7 +120,8 @@ Then(/^an email alert signup page for a policy called "(.*?)" is published to pu
   assert_publishing_api_put_content(
     policy.email_alert_signup_content_id,
     request_json_includes(
-      "format" => "email_alert_signup",
+      "document_type" => "email_alert_signup",
+      "schema_name" => "email_alert_signup",
       "rendering_app" => "email-alert-frontend",
       "publishing_app" => "policy-publisher",
     ),
@@ -135,7 +137,8 @@ Then(/^the policy should be linked to the organisation when published to publish
   assert_publishing_api_put_content(
     @policy.content_id,
     request_json_includes(
-      "format" => "policy",
+      "document_type" => "policy",
+      "schema_name" => "policy",
       "rendering_app" => "finder-frontend",
       "publishing_app" => "policy-publisher",
       "locale" => "en",
@@ -162,7 +165,8 @@ Then(/^the policy should be linked to the person when published to publishing AP
   assert_publishing_api_put_content(
     @policy.content_id,
     request_json_includes(
-      "format" => "policy",
+      "document_type" => "policy",
+      "schema_name" => "policy",
       "rendering_app" => "finder-frontend",
       "publishing_app" => "policy-publisher",
       "locale" => "en",
@@ -189,7 +193,8 @@ Then(/^the policy should be linked to the working group when published to publis
   assert_publishing_api_put_content(
     @policy.content_id,
     request_json_includes(
-      "format" => "policy",
+      "document_type" => "policy",
+      "schema_name" => "policy",
       "rendering_app" => "finder-frontend",
       "publishing_app" => "policy-publisher",
       "locale" => "en",
@@ -217,7 +222,8 @@ Then(/^the policy links should remain unchanged$/) do
   assert_publishing_api_put_content(
     @policy.content_id,
     request_json_includes(
-      "format" => "policy",
+      "document_type" => "policy",
+      "schema_name" => "policy",
       "rendering_app" => "finder-frontend",
       "publishing_app" => "policy-publisher",
       "locale" => "en",

--- a/lib/policies_finder_publisher.rb
+++ b/lib/policies_finder_publisher.rb
@@ -18,7 +18,8 @@ class PoliciesFinderPublisher
   def exportable_attributes
     {
       "base_path" => base_path,
-      "format" => "finder",
+      "document_type" => "finder",
+      "schema_name" => "finder",
       "title" => "Policies",
       "description" => "",
       "public_updated_at" => public_updated_at,

--- a/lib/policy_firehose_finder_publisher.rb
+++ b/lib/policy_firehose_finder_publisher.rb
@@ -19,7 +19,8 @@ class PolicyFirehoseFinderPublisher
   def exportable_attributes
     {
       base_path: base_path,
-      format: "finder",
+      document_type: "finder",
+      schema_name: "finder",
       title: "All policy content",
       phase: "alpha",
       description: "",


### PR DESCRIPTION
`document_type` and `schema_name` have replaced `format`.

Related: https://github.com/alphagov/govuk-content-schemas/pull/348