### PR TITLE
Add linter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ gem 'govspeak','3.3.0'
 group :development, :test do
   gem 'pry-byebug'
   gem 'web-console', '~> 2.0'
+  gem 'govuk-lint'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,6 +42,7 @@ GEM
       builder
       multi_json
     arel (6.0.3)
+    ast (2.3.0)
     autoprefixer-rails (6.2.1)
       execjs
       json
@@ -117,6 +118,9 @@ GEM
       sanitize (~> 2.1.0)
     govuk-content-schema-test-helpers (1.4.0)
       json-schema (~> 2.5.1)
+    govuk-lint (1.2.0)
+      rubocop (~> 0.39.0)
+      scss_lint
     govuk_admin_template (3.5.0)
       bootstrap-sass (= 3.3.5)
       jquery-rails (~> 3.1.3)
@@ -175,6 +179,8 @@ GEM
     omniauth-oauth2 (1.3.1)
       oauth2 (~> 1.0)
       omniauth (~> 1.2)
+    parser (2.3.1.2)
+      ast (~> 2.2)
     pg (0.18.4)
     pkg-config (1.1.7)
     plek (1.10.0)
@@ -183,6 +189,7 @@ GEM
       cliver (~> 0.3.1)
       multi_json (~> 1.0)
       websocket-driver (>= 0.2.0)
+    powerpack (0.1.1)
     pry (0.10.3)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -223,6 +230,7 @@ GEM
       activesupport (= 4.2.7.1)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
+    rainbow (2.1.0)
     raindrops (0.15.0)
     rake (11.2.2)
     rest-client (1.8.0)
@@ -246,16 +254,26 @@ GEM
       rspec-mocks (~> 3.2.0)
       rspec-support (~> 3.2.0)
     rspec-support (3.2.2)
+    rubocop (0.39.0)
+      parser (>= 2.3.0.7, < 3.0)
+      powerpack (~> 0.1)
+      rainbow (>= 1.99.1, < 3.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 1.0, >= 1.0.1)
+    ruby-progressbar (1.8.1)
     safe_yaml (1.0.4)
     sanitize (2.1.0)
       nokogiri (>= 1.4.4)
-    sass (3.4.20)
+    sass (3.4.22)
     sass-rails (5.0.4)
       railties (>= 4.0.0, < 5.0)
       sass (~> 3.1)
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    scss_lint (0.49.0)
+      rake (>= 0.9, < 12)
+      sass (~> 3.4.20)
     selectize-rails (0.12.1)
     slop (3.6.0)
     sprockets (3.7.0)
@@ -277,6 +295,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.2)
+    unicode-display_width (1.1.0)
     unicorn (5.0.1)
       kgio (~> 2.6)
       rack
@@ -313,6 +332,7 @@ DEPENDENCIES
   generic_form_builder (= 0.13.0)
   govspeak (= 3.3.0)
   govuk-content-schema-test-helpers (~> 1.4)
+  govuk-lint
   govuk_admin_template (~> 3.5)
   jquery-ui-rails (~> 5.0.3)
   launchy

--- a/jenkins-schema.sh
+++ b/jenkins-schema.sh
@@ -1,53 +1,8 @@
 #!/bin/bash -xe
-export DISPLAY=:99
+
 export GOVUK_APP_DOMAIN=test.alphagov.co.uk
 export GOVUK_ASSET_ROOT=http://static.test.alphagov.co.uk
-env
+export REPO_NAME="alphagov/govuk-content-schemas"
+export CONTEXT_MESSAGE="Verify policy-publisher against content schemas"
 
-function github_status {
-  STATUS="$1"
-  MESSAGE="$2"
-  gh-status alphagov/govuk-content-schemas "$SCHEMA_GIT_COMMIT" "$STATUS" -d "Build #${BUILD_NUMBER} ${MESSAGE}" -u "$BUILD_URL" -c "policy publisher contract tests" >/dev/null
-}
-
-function error_handler {
-  trap - ERR # disable error trap to avoid recursion
-  local parent_lineno="$1"
-  local message="$2"
-  local code="${3:-1}"
-  if [[ -n "$message" ]] ; then
-    echo "Error on or near line ${parent_lineno}: ${message}; exiting with status ${code}"
-  else
-    echo "Error on or near line ${parent_lineno}; exiting with status ${code}"
-  fi
-  github_status failure "failed on Jenkins"
-  exit "${code}"
-}
-
-trap "error_handler ${LINENO}" ERR
-github_status pending "is running on Jenkins"
-
-# Ensure there are no artefacts left over from previous builds
-git clean -fdx
-
-# Clone govuk-content-schemas dependency for contract tests
-rm -rf tmp/govuk-content-schemas
-git clone git@github.com:alphagov/govuk-content-schemas.git tmp/govuk-content-schemas
-cd tmp/govuk-content-schemas
-git checkout $SCHEMA_GIT_COMMIT
-cd ../..
-
-time bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
-RAILS_ENV=test bundle exec rake db:reset
-RAILS_ENV=test GOVUK_CONTENT_SCHEMAS_PATH=tmp/govuk-content-schemas time bundle exec rake
-
-EXIT_STATUS=$?
-echo "EXIT STATUS: $EXIT_STATUS"
-
-if [ "$EXIT_STATUS" == "0" ]; then
-  github_status success "succeeded on Jenkins"
-else
-  github_status failure "failed on Jenkins"
-fi
-
-exit $EXIT_STATUS
+exec ./jenkins.sh

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,54 +1,7 @@
 #!/bin/bash -xe
-export DISPLAY=:99
-export RAILS_ENV=test
-export REPO_NAME="alphagov/policy-publisher"
+export REPO_NAME=${REPO_NAME:-"alphagov/policy-publisher"}
+export CONTEXT_MESSAGE=${CONTEXT_MESSAGE:-"default"}
+export GH_STATUS_GIT_COMMIT=${SCHEMA_GIT_COMMIT:-${GIT_COMMIT}}
+export PRECOMPILE_ASSETS="yes"
 
-function github_status {
-  REPO_NAME="$1"
-  STATUS="$2"
-  MESSAGE="$3"
-  gh-status "$REPO_NAME" "$GIT_COMMIT" "$STATUS" -d "Build #${BUILD_NUMBER} ${MESSAGE}" -u "$BUILD_URL" >/dev/null
-}
-
-function error_handler {
-  trap - ERR # disable error trap to avoid recursion
-  local parent_lineno="$1"
-  local message="$2"
-  local code="${3:-1}"
-  if [[ -n "$message" ]] ; then
-    echo "Error on or near line ${parent_lineno}: ${message}; exiting with status ${code}"
-  else
-    echo "Error on or near line ${parent_lineno}; exiting with status ${code}"
-  fi
-  github_status "$REPO_NAME" failure "failed on Jenkins"
-  exit "${code}"
-}
-
-trap "error_handler ${LINENO}" ERR
-github_status "$REPO_NAME" pending "is running on Jenkins"
-
-# Try to merge master into the current branch, and abort if it doesn't exit
-# cleanly (ie there are conflicts). This will be a noop if the current branch
-# is master.
-git merge --no-commit origin/master || git merge --abort
-
-bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment --without development
-bundle exec rake db:reset
-bundle exec rake assets:clean assets:precompile
-
-# Clone govuk-content-schemas depedency for tests
-rm -rf tmp/govuk-content-schemas
-git clone git@github.com:alphagov/govuk-content-schemas.git tmp/govuk-content-schemas
-
-RAILS_ENV=test GOVUK_CONTENT_SCHEMAS_PATH=tmp/govuk-content-schemas bundle exec rake
-
-
-export EXIT_STATUS=$?
-
-if [ "$EXIT_STATUS" == "0" ]; then
-  github_status "$REPO_NAME" success "succeeded on Jenkins"
-else
-  github_status "$REPO_NAME" failure "failed on Jenkins"
-fi
-
-exit $EXIT_STATUS
+curl https://raw.githubusercontent.com/alphagov/govuk-ci-scripts/master/rails-app.sh | bash


### PR DESCRIPTION
According to https://docs.google.com/spreadsheets/d/1FJmr39c9eXgpA-qHUU6GAbbJrnenc0P7JcyY2NB9PgU/edit#gid=1480786499 policy-publisher does not have `govuk-lint` set. This commit:

- Includes govuk-lint in the Gemfile;
- changes the jenkins' scripts to use the scripts from `govuk-ci-scripts` (so that the linter runs on jenkins)
