### PR TITLE
After upgrading rails, we started seeing deprecation errors like this:

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -265,8 +265,8 @@ GEM
     sanitize (2.1.0)
       nokogiri (>= 1.4.4)
     sass (3.4.22)
-    sass-rails (5.0.4)
-      railties (>= 4.0.0, < 5.0)
+    sass-rails (5.0.6)
+      railties (>= 4.0.0, < 6)
       sass (~> 3.1)
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
@@ -285,7 +285,7 @@ GEM
       sprockets (>= 3.0.0)
     thor (0.19.1)
     thread_safe (0.3.5)
-    tilt (2.0.1)
+    tilt (2.0.5)
     timecop (0.8.0)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
@@ -352,4 +352,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.10.6
+   1.11.2


### PR DESCRIPTION
```
DEPRECATION WARNING: Sprockets method `register_engine` is deprecated.
Please register a mime type using `register_mime_type` then
use `register_compressor` or `register_transformer`.
```

Upgrading sass-rails fixes those.