### PR TITLE
Make user organisation nullable

### DIFF
--- a/db/migrate/20160822113751_make_user_organisation_nullable.rb
+++ b/db/migrate/20160822113751_make_user_organisation_nullable.rb
@@ -1,0 +1,13 @@
+class MakeUserOrganisationNullable < ActiveRecord::Migration
+  def up
+    change_table :users do |t|
+      t.change :organisation_content_id, :string, default: nil, null: true
+    end
+  end
+
+  def down
+    change_table :users do |t|
+      t.change :organisation_content_id, :string, default: "", null: false
+    end
+  end
+end

--- a/db/migrate/20160824152729_nullify_user_organisations.rb
+++ b/db/migrate/20160824152729_nullify_user_organisations.rb
@@ -1,0 +1,5 @@
+class NullifyUserOrganisations < ActiveRecord::Migration
+  def up
+    User.where(organisation_content_id: "").update_all(organisation_content_id: nil)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160614093540) do
+ActiveRecord::Schema.define(version: 20160824152729) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -55,7 +55,7 @@ ActiveRecord::Schema.define(version: 20160614093540) do
     t.string  "permissions"
     t.boolean "remotely_signed_out",     default: false
     t.boolean "disabled",                default: false
-    t.string  "organisation_content_id", default: "",    null: false
+    t.string  "organisation_content_id"
   end
 
 end


### PR DESCRIPTION
When we make changes to a regular user in signon, they get synced to the apps.
The user that is used to make the gds-api-adapters request is "SSO Permissions Push User",
and they don't belong to an organisation.

As part of the Push User authentication, something tries to write to the user record,
and it uses null for the organisation. In other apps, this field is defined as nullable
so it works fine, but policy publisher defined it as not nullable and expects the value
to be empty string.

This changes policy publisher to use the same type as other apps, eg content tagger:
https://github.com/alphagov/content-tagger/blob/master/db/schema.rb

Debugged with @jackscotti 
Discovered by @jennyd 

Question before merge: do we need to convert existing data to nulls instead of empty string? Or will it resolve itself?