### PR TITLE
Add publishing_api:publish rake task

### DIFF
--- a/lib/policies_finder_publisher.rb
+++ b/lib/policies_finder_publisher.rb
@@ -76,6 +76,7 @@ private
         filterable: true,
         preposition: "from",
         name: "Organisation",
+        # finder-frontend will fetch the `allowed_values` for this from rummager.
       },
     ]
   end

--- a/lib/policy_firehose_finder_publisher.rb
+++ b/lib/policy_firehose_finder_publisher.rb
@@ -107,6 +107,7 @@ private
         type: "text",
         display_as_result_metadata: true,
         filterable: true
+        # finder-frontend will fetch the `allowed_values` for this from rummager.
       },
       {
         key: "policies",

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -12,6 +12,9 @@ namespace :publishing_api do
     end
   end
 
+  desc "Publish semi-static pages. This is run after each deploy."
+  task publish: [:publish_policies_finder, :publish_policy_firehose_finder]
+
   desc "Publish the Policies Finder to the Publishing API"
   task publish_policies_finder: :environment do
     require "policies_finder_publisher"


### PR DESCRIPTION
Since https://github.com/alphagov/finder-frontend/pull/212 the organisations are fetched from rummager in finder-frontend. 

The republish rake task has never been run, so the old data is still there, causing old orgs to be displayed. The rake task we're adding will be run after each deploy, so this won't happen again.
