### PR TITLE
Don't send signup_link

### DIFF
--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -70,7 +70,6 @@ private
         policies: [policy.slug]
       },
       human_readable_finder_format: 'Policy',
-      signup_link: '',
       summary: summary,
       show_summaries: false,
       facets: facets,


### PR DESCRIPTION
It's empty now and doesn't serve a purpose. Allows us to remove it from
the schemas (https://github.com/alphagov/govuk-content-schemas/pull/386).