### PR TITLE
Don't send govspeak to search

### DIFF
--- a/lib/policy_actions/search_indexer.rb
+++ b/lib/policy_actions/search_indexer.rb
@@ -13,7 +13,7 @@ class SearchIndexer
   def document
     {
       title: policy.name,
-      description: policy.description,
+      description: search_description,
       link: policy.base_path,
       slug: policy.slug,
       indexable_content: "",
@@ -24,6 +24,10 @@ class SearchIndexer
   end
 
 private
+
+  def search_description
+    Govspeak::Document.new(policy.description).to_text
+  end
 
   def people
     fetched_people = policy.people_content_ids.map { |content_id| fetcher.find_person(content_id) }.compact

--- a/spec/lib/policy_actions/search_indexer_spec.rb
+++ b/spec/lib/policy_actions/search_indexer_spec.rb
@@ -46,12 +46,13 @@ RSpec.describe SearchIndexer do
     policy = FactoryGirl.create(:policy,
       people_content_ids: people.map {|person| person["content_id"] },
       working_group_content_ids: working_groups.map {|wg| wg["content_id"] },
+      description: "Something with **govspeak**"
     )
     indexer = SearchIndexer.new(policy)
 
     expected_json = {
       title: policy.name,
-      description: policy.description,
+      description: "Something with govspeak",
       link: policy.base_path,
       slug: policy.slug,
       indexable_content: "",


### PR DESCRIPTION
This removes the govspeak from the search description before sending it to rummager.

https://trello.com/c/eVj9vqwL