### PR TITLE
Delete old Jenkins shell scripts

### DIFF
--- a/jenkins-schema.sh
+++ b/jenkins-schema.sh
@@ -1,8 +1,0 @@
-#!/bin/bash -xe
-
-export GOVUK_APP_DOMAIN=test.alphagov.co.uk
-export GOVUK_ASSET_ROOT=http://static.test.alphagov.co.uk
-export REPO_NAME="alphagov/govuk-content-schemas"
-export CONTEXT_MESSAGE="Verify policy-publisher against content schemas"
-
-exec ./jenkins.sh

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,7 +1,0 @@
-#!/bin/bash -xe
-export REPO_NAME=${REPO_NAME:-"alphagov/policy-publisher"}
-export CONTEXT_MESSAGE=${CONTEXT_MESSAGE:-"default"}
-export GH_STATUS_GIT_COMMIT=${SCHEMA_GIT_COMMIT:-${GIT_COMMIT}}
-export PRECOMPILE_ASSETS="yes"
-
-curl https://raw.githubusercontent.com/alphagov/govuk-ci-scripts/master/rails-app.sh | bash


### PR DESCRIPTION
The contents of these scripts have been migrated to the Jenkinsfile.

These were not safe to delete until now because they were still used to test the content schemas on Jenkins 1, but those tests have now also been migrated to Jenkins 2.

https://trello.com/c/S4DZbsPa/285-jenkins-2-migration