### PR TITLE
Fix eager loading files

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -26,8 +26,8 @@ module PolicyPublisher
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
 
-    config.autoload_paths += %W(#{config.root}/lib)
-    config.autoload_paths += Dir["#{config.root}/lib/**/"]
+    config.eager_load_paths += %W(#{config.root}/lib)
+    config.eager_load_paths += Dir["#{config.root}/lib/**/"]
 
     # Better forms
     require "admin_form_builder"


### PR DESCRIPTION
Rails doesn't autoload files in production anymore. This causes an error on integration, because Rails can't load the `Services` module.

More info: https://github.com/rails/rails/commit/80b416f5e692ae79f4062f59fed6c7d7648a8af0