### PR TITLE
Remove out of date comment from database config

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -1,5 +1,3 @@
-# This file overwritten on deploy
-
 default: &default
   adapter: postgresql
   encoding: unicode


### PR DESCRIPTION
This file is no longer overwritten on deploy however a DATABASE_URL variable will be stored in the environment which will take precedence. See http://guides.rubyonrails.org/configuring.html#configuring-a-database