### PR TITLE
Send update type with put content

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'govuk_admin_template', '~> 5.0.1'
 gem 'generic_form_builder', '0.13.0'
 gem 'selectize-rails', '~> 0.12.1'
 
-gem 'gds-api-adapters', '~> 41.5'
+gem 'gds-api-adapters', '~> 47.2'
 
 gem 'govspeak', '~> 5.0.2'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,7 +96,7 @@ GEM
       activesupport (>= 3.0.0)
     faraday (0.11.0)
       multipart-post (>= 1.2, < 3)
-    gds-api-adapters (41.5.0)
+    gds-api-adapters (47.2.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -242,7 +242,7 @@ GEM
     rainbow (2.2.1)
     raindrops (0.18.0)
     rake (12.0.0)
-    rest-client (2.0.1)
+    rest-client (2.0.2)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
@@ -335,7 +335,7 @@ DEPENDENCIES
   cucumber-rails
   database_cleaner
   factory_girl (~> 4.8)
-  gds-api-adapters (~> 41.5)
+  gds-api-adapters (~> 47.2)
   gds-sso (~> 13.2)
   generic_form_builder (= 0.13.0)
   govspeak (~> 5.0.2)
@@ -359,4 +359,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.14.5
+   1.15.1

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -18,6 +18,7 @@ class ContentItemPresenter
       rendering_app: "finder-frontend",
       routes: routes,
       details: details,
+      update_type: "major",
     }
   end
 

--- a/app/presenters/email_alert_signup_content_item_presenter.rb
+++ b/app/presenters/email_alert_signup_content_item_presenter.rb
@@ -16,6 +16,7 @@ class EmailAlertSignupContentItemPresenter
       rendering_app: "email-alert-frontend",
       routes: routes,
       details: details,
+      update_type: "major",
     }
   end
 

--- a/lib/policies_finder_publisher.rb
+++ b/lib/policies_finder_publisher.rb
@@ -28,6 +28,7 @@ class PoliciesFinderPublisher
       "rendering_app" => "finder-frontend",
       "routes" => routes,
       "details" => details,
+      "update_type" => "major",
     }
   end
 

--- a/lib/policies_finder_publisher.rb
+++ b/lib/policies_finder_publisher.rb
@@ -12,7 +12,7 @@ class PoliciesFinderPublisher
 
   def publish
     Services.publishing_api.put_content(CONTENT_ID, exportable_attributes)
-    Services.publishing_api.publish(CONTENT_ID, "major")
+    Services.publishing_api.publish(CONTENT_ID)
   end
 
   def exportable_attributes

--- a/lib/policy_actions/content_item_publisher.rb
+++ b/lib/policy_actions/content_item_publisher.rb
@@ -2,7 +2,7 @@
 class ContentItemPublisher
   attr_reader :policy, :update_type
 
-  def initialize(policy, update_type: "major")
+  def initialize(policy, update_type: nil)
     @policy = policy
     @update_type = update_type
   end

--- a/lib/policy_firehose_finder_publisher.rb
+++ b/lib/policy_firehose_finder_publisher.rb
@@ -13,7 +13,7 @@ class PolicyFirehoseFinderPublisher
 
   def publish
     publishing_api.put_content(CONTENT_ID, exportable_attributes)
-    publishing_api.publish(CONTENT_ID, 'major')
+    publishing_api.publish(CONTENT_ID)
   end
 
   def exportable_attributes

--- a/lib/policy_firehose_finder_publisher.rb
+++ b/lib/policy_firehose_finder_publisher.rb
@@ -30,6 +30,7 @@ class PolicyFirehoseFinderPublisher
       rendering_app: "finder-frontend",
       routes: routes,
       details: details,
+      update_type: "major",
     }
   end
 

--- a/spec/lib/publisher_spec.rb
+++ b/spec/lib/publisher_spec.rb
@@ -29,7 +29,6 @@ RSpec.describe Publisher do
 
       assert_publishing_api_publish(
         policy.content_id,
-        update_type: "major"
       )
 
       assert_publishing_api_patch_links(
@@ -58,7 +57,6 @@ RSpec.describe Publisher do
 
       assert_publishing_api_publish(
         policy.content_id,
-        update_type: "major"
       )
 
       assert_publishing_api_patch_links(


### PR DESCRIPTION
Sending it on publish has been deprecated in favour of including it when sending a put content.

[Trello Card](https://trello.com/c/LnJlkb9e/987-5-deprecate-the-usage-of-updatetype-in-publish-for-publishing-api-and-update-usage-across-govuk)