### PR TITLE
Update title and description of Policy finders

### DIFF
--- a/lib/policies_finder_publisher.rb
+++ b/lib/policies_finder_publisher.rb
@@ -20,7 +20,7 @@ class PoliciesFinderPublisher
       "base_path" => base_path,
       "document_type" => "finder",
       "schema_name" => "finder",
-      "title" => "Policies",
+      "title" => "Policy content",
       "description" => "",
       "public_updated_at" => public_updated_at,
       "locale" => "en",
@@ -62,6 +62,7 @@ private
       filter: {
         document_type: "policy"
       },
+      summary: "Search for information about government policy or filter by department.",
       show_summaries: false,
       facets: facets,
     }

--- a/lib/policy_firehose_finder_publisher.rb
+++ b/lib/policy_firehose_finder_publisher.rb
@@ -21,7 +21,7 @@ class PolicyFirehoseFinderPublisher
       base_path: base_path,
       document_type: "finder",
       schema_name: "finder",
-      title: "All policy content",
+      title: "Policy content",
       phase: "alpha",
       description: "",
       public_updated_at: public_updated_at,
@@ -68,6 +68,7 @@ private
       reject: {
         policies: ["_MISSING"],
       },
+      summary: "Search for information about government policy or filter by department, people or policy area.",
       show_summaries: false,
       facets: facets,
     }


### PR DESCRIPTION
Trello card: https://trello.com/c/q0BeJMlR

## Motivation

We are preparing to run an A/B test that compares the [Policies Finder](https://www.gov.uk/government/policies) with the [All Policy](https://www.gov.uk/government/policies/all) finder. 

For the users to think they are looking at an updated version of the original page we need to change the title on both finders to be the same.

## Expected Changes

### Policies page
#### Before
![screen shot 2017-08-14 at 18 41 08](https://user-images.githubusercontent.com/5793815/29283897-79650672-8120-11e7-88a5-7d4995f833a5.png)

#### After
![screen shot 2017-08-14 at 18 40 29](https://user-images.githubusercontent.com/5793815/29283871-5e676400-8120-11e7-9f17-9951ecd70216.png)

### All policies page
#### Before
![screen shot 2017-08-14 at 18 41 19](https://user-images.githubusercontent.com/5793815/29283902-7da03edc-8120-11e7-9f30-1679a57893e3.png)

#### After
![screen shot 2017-08-14 at 18 40 50](https://user-images.githubusercontent.com/5793815/29283894-762b8940-8120-11e7-9b69-3a7fe8855d57.png)
