### PR TITLE
Revert the changes made to the Policies finder titles

### DIFF
--- a/lib/policies_finder_publisher.rb
+++ b/lib/policies_finder_publisher.rb
@@ -20,7 +20,7 @@ class PoliciesFinderPublisher
       "base_path" => base_path,
       "document_type" => "finder",
       "schema_name" => "finder",
-      "title" => "Policy content",
+      "title" => "Policies",
       "description" => "",
       "public_updated_at" => public_updated_at,
       "locale" => "en",

--- a/lib/policy_firehose_finder_publisher.rb
+++ b/lib/policy_firehose_finder_publisher.rb
@@ -21,7 +21,7 @@ class PolicyFirehoseFinderPublisher
       base_path: base_path,
       document_type: "finder",
       schema_name: "finder",
-      title: "Policy content",
+      title: "All policy content",
       phase: "alpha",
       description: "",
       public_updated_at: public_updated_at,


### PR DESCRIPTION
Trello card: https://trello.com/c/IaqLA1eG

## Motivation

Revert the changes to the titles made in PR: https://github.com/alphagov/policy-publisher/pull/167

The titles of the Policies and the All policy content finders were changed to match each other as part of an A/B test so that users would think that they are looking at different versions of the same page.

The A/B test finishes on September 13th, so we can revert the titles.

We are leaving the descriptions in place as they are an improvement.