### PR TITLE
Populate the description field

### DIFF
--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -39,7 +39,7 @@ private
   end
 
   def description
-    ""
+    Govspeak::Document.new(policy.description).to_html
   end
 
   def public_updated_at
@@ -71,7 +71,7 @@ private
         policies: [policy.slug]
       },
       human_readable_finder_format: 'Policy',
-      summary: summary,
+      summary: description,
       show_summaries: false,
       facets: facets,
       emphasised_organisations: policy.lead_organisation_content_ids,
@@ -101,10 +101,6 @@ private
     else
       {}
     end
-  end
-
-  def summary
-    Govspeak::Document.new(policy.description).to_html
   end
 
   def alternative_policies


### PR DESCRIPTION
Previously the description was only being sent in details->summary. Updating
this to also send it in description should add the following functionality:

* Simplify the rummager code which uses the description in internal search
results by removing this customisation
* Add a metatag description to the policy pages whcih can more easily be
picked up by search engines.

I did consider remove the details->summary field, however have left it at
this stage as I am not 100% sure were else it is used within the system.

https://trello.com/c/OBhgB1Lw/531-code-tidy-up

This is required to unlock: https://github.com/alphagov/rummager/pull/1095