### PR TITLE
Change handling of sub policies

### DIFF
--- a/app/forms/policy_form.rb
+++ b/app/forms/policy_form.rb
@@ -12,7 +12,6 @@ class PolicyForm
     scotland_policy_url
     wales
     wales_policy_url
-    parent_policy_ids
   ].freeze
 
   LINK_ATTRIBUTES = %w[
@@ -20,6 +19,7 @@ class PolicyForm
     supporting_organisation_content_ids
     people_content_ids
     working_group_content_ids
+    parent_policy_ids
   ].freeze
 
   attr_accessor(*ATTRIBUTES)
@@ -71,6 +71,7 @@ class PolicyForm
     form.supporting_organisation_content_ids = policy.supporting_organisation_content_ids
     form.people_content_ids = policy.people_content_ids
     form.working_group_content_ids = policy.working_group_content_ids
+    form.parent_policy_ids = policy.parent_policy_ids
     form
   end
 
@@ -88,6 +89,7 @@ class PolicyForm
     policy.set_organisation_priority(@lead_organisation_content_ids, @supporting_organisation_content_ids)
     policy.people_content_ids = @people_content_ids
     policy.working_group_content_ids = @working_group_content_ids
+    policy.parent_policy_ids = @parent_policy_ids
 
     policy.update_attributes(attributes) && publish!
   end
@@ -109,7 +111,7 @@ class PolicyForm
   end
 
   def sub_policy?
-    sub_policy
+    policy.sub_policy?
   end
 
 private

--- a/app/views/policies/_form.html.erb
+++ b/app/views/policies/_form.html.erb
@@ -32,14 +32,12 @@
           class: 'select2',
           data: { placeholder: 'Choose working groups…' } } %>
 
-  <% if policy_form.sub_policy? %>
-    <%= form.select :parent_policy_ids,
-          policies_areas_data_container,
-          { label: "Part of" },
-          { multiple: true,
-            class: 'select2',
-            data: { placeholder: 'Choose parent policies…' } } %>
-  <% end %>
+  <%= form.select :parent_policy_ids,
+        policies_areas_data_container,
+        { label: "Part of" },
+        { multiple: true,
+          class: 'select2',
+          data: { placeholder: 'Choose parent policies…' } } %>
 
   <h4>Applicable nations</h4>
 


### PR DESCRIPTION
Previously, sub policies could be created, but when you edited them,
they would revert to being a policy, as the parent_policy_ids are not
persisted. Also, the form would show in the policy editing mode, and
be missing the "Part of" field.

As far as I can tell, this change was an unintentional side effect of
e310a1a which splits out link
attributes, but keeps parent_policy_ids as an attribute. The attribute
values are copied to the form via the as_json method, but this will
ignore the associated policies, therefore the default value of [] is
used.

I'm unsure if this is useful functionality to have, but it's kind of
supported, so lets fix it.