### PR TITLE
Handle external URLs for Signon

### DIFF
--- a/config/initializers/gds_sso.rb
+++ b/config/initializers/gds_sso.rb
@@ -2,5 +2,5 @@ GDS::SSO.config do |config|
   config.user_model   = 'User'
   config.oauth_id     = ENV['OAUTH_ID'] || "abcdefghjasndjkasndcontenttagger"
   config.oauth_secret = ENV['OAUTH_SECRET'] || "secret"
-  config.oauth_root_url = Plek.find('signon')
+  config.oauth_root_url = Plek.new.external_url_for('signon')
 end


### PR DESCRIPTION
Use the new external_url_for method of Plek to generate external URLs
for Signon. This makes Policy Publisher more compatible with
environments where there is a difference between internal and external
routing, which is the way GOV.UK is being deployed to Amazon Web
Services.