### PR TITLE
Stop using the policy_areas link type

### DIFF
--- a/app/presenters/links_presenter.rb
+++ b/app/presenters/links_presenter.rb
@@ -13,8 +13,7 @@ class LinksPresenter
         people: people_content_ids,
         working_groups: working_group_content_ids,
         related: related,
-        email_alert_signup: email_alert_signup_content_id,
-        policy_areas: policy_areas,
+        email_alert_signup: email_alert_signup_content_id
       }
     }
   end
@@ -43,9 +42,5 @@ private
 
   def related
     policy.related_policies.map(&:content_id)
-  end
-
-  def policy_areas
-    policy.parent_policies.map(&:content_id)
   end
 end

--- a/features/step_definitions/policy_steps.rb
+++ b/features/step_definitions/policy_steps.rb
@@ -143,8 +143,7 @@ Then(/^the policy should be linked to the organisation when published to publish
         "people" => [],
         "working_groups" => [],
         "related" => [],
-        "email_alert_signup" => [@policy.email_alert_signup_content_id],
-        "policy_areas" => [],
+        "email_alert_signup" => [@policy.email_alert_signup_content_id]
       }
   )
 end
@@ -169,8 +168,7 @@ Then(/^the policy should be linked to the person when published to publishing AP
         "people" => [person_1["content_id"]],
         "working_groups" => [],
         "related" => [],
-        "email_alert_signup" => [@policy.email_alert_signup_content_id],
-        "policy_areas" => [],
+        "email_alert_signup" => [@policy.email_alert_signup_content_id]
       }
   )
 end
@@ -195,8 +193,7 @@ Then(/^the policy should be linked to the working group when published to publis
         "people" => [],
         "working_groups" => [working_group_1["content_id"]],
         "related" => [],
-        "email_alert_signup" => [@policy.email_alert_signup_content_id],
-        "policy_areas" => [],
+        "email_alert_signup" => [@policy.email_alert_signup_content_id]
       }
   )
 end
@@ -222,8 +219,7 @@ Then(/^the policy links should remain unchanged$/) do
         "people" => [person_1["content_id"], person_2["content_id"]],
         "working_groups" => [working_group_1["content_id"], working_group_2["content_id"]],
         "related" => [],
-        "email_alert_signup" => [@policy.email_alert_signup_content_id],
-        "policy_areas" => [],
+        "email_alert_signup" => [@policy.email_alert_signup_content_id]
       }
   )
 end

--- a/spec/presenters/links_presenter_spec.rb
+++ b/spec/presenters/links_presenter_spec.rb
@@ -44,15 +44,6 @@ RSpec.describe LinksPresenter do
       expect(attributes["links"]["related"]).to eq([related_policy.content_id])
     end
 
-    it "includes policies" do
-      sub_policy = create(:sub_policy)
-      policy_area = sub_policy.parent_policies.first
-
-      attributes = LinksPresenter.new(sub_policy).exportable_attributes.as_json
-
-      expect(attributes["links"]["policy_areas"]).to eq([policy_area.content_id])
-    end
-
     it "includes the linked email alert signup" do
       policy = create(:policy)
 


### PR DESCRIPTION
This is causing confusion, as Policy Publisher can use this to
represent the relationship between policies, and in this context, it
doesn't have anything to do with the content in the Publishing API
with a document type of `policy_area`.

The `policy_areas` link type is used elsewhere to represent the
relationship between content (many document types) to policy
areas (either with the document type `policy_area`, or
`placeholder_policy_area`). The potential to do something different
here could cause confusion if it was used.

I don't anticipate removing this to cause any immediate
problems. Either due to issues with Policy Publisher [1] or otherwise,
there are currently no sub policies, so there are no policies using
the `policy_areas` link type in this way.

Given the current work around taxonomies and navigation, I'm not sure
of the future of Policy Publisher, and policies in general, so for
now, I think the thing to do is remove the use of this link type. If
in the future sub policies are used again, and it becomes useful to
represent that relationship in the Publishing API, I don't see any
issues with adding this functionality back, providing a different and
appropriate link type is used.

1: Details in 9695f347b0f2356c13bf504ee38b15b25e031353