### PR TITLE
Add rake task to unpublish and redirect policies

### DIFF
--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -30,4 +30,23 @@ namespace :publishing_api do
       alternative_path: "/government/policies"
     )
   end
+
+  desc "Unpublish one or more Policies from a CSV file (policy,taxon) given as argument"
+  task :unpublish_policies, [:csv_file_path] => :environment do |_t, args|
+    CSV.foreach(args[:file_path], headers: true) do |row|
+      from_policy = Policy.find_by(slug: row['policy'].split('/').last)
+
+      if from_policy.present?
+        Services.publishing_api.unpublish(
+          from_policy.content_id,
+          type: 'redirect',
+          alternative_path: row['taxon'],
+          discard_drafts: true
+        )
+        puts "The '#{from_policy.name}' Policy has been unpublished"
+      else
+        puts "No Policy found for path #{row['policy']}"
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR addresses [Trello card 159 (Create a system to unpublish Policies in bulk)](https://trello.com/c/WwfLJcPm/159-create-a-system-to-unpublish-policies-in-bulk).

The added rake task accepts a csv file path as argument. The file will have
"policy" and "taxon" as the two columns headers and the content will be
the paths to the policy and to the taxon.

Example:
```
policy,taxon
/government/policies/equality,/society-and-culture/equality
/government/policies/animal-welfare,/environment/animal-welfare
```